### PR TITLE
Use --force-local in case of epoch in version number

### DIFF
--- a/src/PKGBUILD
+++ b/src/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Hunter Wittenborn: <hunter@hunterwittenborn.com>
 
 pkgname=makedeb
-pkgver=5.8.5
+pkgver=5.8.6
 pkgrel=1
 pkgdesc="Create Debian archives from PKGBUILDs (git release)"
 arch=('any')

--- a/src/functions/fakeroot_build.sh
+++ b/src/functions/fakeroot_build.sh
@@ -7,7 +7,7 @@ fakeroot_build() {
     for package in ${pkgname[@]}; do
         unset depends optdepends conflicts provides replaces license
 
-        tar -xf "${package}-${built_archive_version}-${makepkg_arch}.${package_extension}" -C "${pkgdir}/${package}"
+        tar --force-local -xf "${package}-${built_archive_version}-${makepkg_arch}.${package_extension}" -C "${pkgdir}/${package}"
         cd "${pkgdir}/${package}"
         get_variables
 


### PR DESCRIPTION
An epoch in the version number inserts a colon into the file name which tar interprets as a protocol separator unless `--force-local` is included.