### PR TITLE
Bump package version

### DIFF
--- a/.data.json
+++ b/.data.json
@@ -1,5 +1,5 @@
 {
-	"current_pkgver": "8.2.0",
+	"current_pkgver": "8.2.1",
 	"current_pkgrel": "1",
 	"makedeb_man_epoch": "1635393570",
 	"pkgbuild_man_epoch": "1635393570"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+makedeb (8.2.1-1) unstable; urgency=medium
+
+  * Initial release (Closes: #998039).
+
+ -- Leo Puvilland <lpuvilla0001@mymail.lausd.net>  Thu, 04 Nov 2021 17:49:35 -0700
+
 makedeb (8.2.0-2) unstable; urgency=medium
 
   * Depend on jq


### PR DESCRIPTION
According to [this link](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=998041), we need to keep the debian revision at -1 until sponsorship is over. This means we might need to not touch it for a while... Anyways, for now this should fix it.