### PR TITLE
Add Github CI on every PR

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,15 +9,15 @@ jobs:
       TARGET: local
       RELEASE: alpha
     container:
-      image: proget.hunterwittenborn.com/docker/makedeb/makedeb-alpha:ubuntu-focal
+      image: sardine123/makedeb-github-ci:ubuntu-focal
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          path: "/home/makedeb/makedeb"
+          path: "makedeb"
       - name: Generate PKGBUILD and build with makedeb
         run: |
-          cd /home/makedeb/makedeb
+          cd makedeb
           sudo chown -R makedeb:makedeb .
           sudo apt update && sudo apt install -y git jq
           cd PKGBUILD

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    env:
+      TARGET: local
+      RELEASE: alpha
     container:
       image: proget.hunterwittenborn.com/docker/makedeb/makedeb:ubuntu-focal
     steps:
@@ -20,14 +23,11 @@ jobs:
           cd PKGBUILD
           ./pkgbuild.sh > PKGBUILD
           PACMAN='/usr/bin/true' makedeb -s --no-confirm
-        env:
-          TARGET: local
-          RELEASE: alpha
       - name: Upload build output
         uses: actions/upload-artifact@v2
         with:
           name: makedeb-build
-          path: *.deb
+          path: "*.deb"
         retention-days: 7
 
   build-native:
@@ -50,5 +50,5 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: makedeb-native-build
-          path: *.deb
+          path: "*.deb"
         retention-days: 7

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,6 +14,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: add VERSION env var
+        run: |
+          cat << EOF > .env
+          VERSION=$(cat .data.json | jq -r '.current_pkgver')
+          EOF
       - name: Install deps
         run: |
          sudo apt update
@@ -30,7 +36,7 @@ jobs:
           PACMAN='/usr/bin/true' makedeb -s --no-confirm
           ls -a
       - name: Rename result
-        run: mv *.deb makedeb.deb
+        run: source .env && mv makedeb-alpha_$VERSION-1_all.deb makedeb.deb
       - name: Upload build output
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,9 +34,9 @@ jobs:
           cd PKGBUILD
           ./pkgbuild.sh > PKGBUILD
           PACMAN='/usr/bin/true' makedeb -s --no-confirm
-          ls -a
-      - name: Rename result
-        run: source .env && mv makedeb-alpha_$VERSION-1_all.deb makedeb.deb
+          source .env && mv makedeb-alpha_$VERSION-1_all.deb makedeb.deb
+      #- name: Rename result
+      #  run: source .env && mv makedeb-alpha_$VERSION-1_all.deb makedeb.deb
       - name: Upload build output
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ jobs:
       TARGET: local
       RELEASE: alpha
     container:
-      image: proget.hunterwittenborn.com/docker/makedeb/makedeb:ubuntu-focal
+      image: proget.hunterwittenborn.com/docker/makedeb/makedeb-alpha:ubuntu-focal
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,14 +17,13 @@ jobs:
         run: |
          sudo apt update
          DEBIAN_FRONTEND=noninteractive sudo apt install wget gpg sudo -y
-         wget -qO - "https://proget.hunterwittenborn.com/debian-feeds/makedeb.pub" | gpg --dearmor | tee /usr/share/keyrings/makedeb-archive-keyring.gpg 1> /dev/null
-         echo "deb [signed-by=/usr/share/keyrings/makedeb-archive-keyring.gpg arch=all] https://proget.hunterwittenborn.com/ makedeb main" | tee /etc/apt/sources.list.d/makedeb.list
+         wget -qO - "https://proget.hunterwittenborn.com/debian-feeds/makedeb.pub" | gpg --dearmor | sudo tee /usr/share/keyrings/makedeb-archive-keyring.gpg 1> /dev/null
+         echo "deb [signed-by=/usr/share/keyrings/makedeb-archive-keyring.gpg arch=all] https://proget.hunterwittenborn.com/ makedeb main" | sudo tee /etc/apt/sources.list.d/makedeb.list
          sudo apt update
          sudo apt install makedeb-alpha -y
       - name: Generate PKGBUILD and build with makedeb
         run: |
           cd makedeb
-          sudo chown -R makedeb:makedeb .
           sudo apt update && sudo apt install -y git jq
           cd PKGBUILD
           ./pkgbuild.sh > PKGBUILD

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,7 +36,7 @@ jobs:
           cd PKGBUILD
           ./pkgbuild.sh > PKGBUILD
           PACMAN='/usr/bin/true' makedeb -s --no-confirm
-          mv makedeb-alpha_$VERSION-1_all.deb makedeb.deb
+          mv makedeb-alpha_$(cat .data.json | jq -r '.current_pkgver + "-" + .current_pkgrel')_all.deb makedeb.deb
       #- name: Rename result
       #  run: source .env && mv makedeb-alpha_$VERSION-1_all.deb makedeb.deb
       - name: Upload build output

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,6 @@
 name: Build makedeb
 on:
  pull_request:
- push:
 
 jobs:
   build:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,6 @@
 name: Build makedeb
 on:
  pull_request:
-
 jobs:
   build:
     runs-on: ubuntu-20.04
@@ -29,6 +28,7 @@ jobs:
           cd PKGBUILD
           ./pkgbuild.sh > PKGBUILD
           PACMAN='/usr/bin/true' makedeb -s --no-confirm
+          ls -a
       - name: Rename result
         run: mv *.deb makedeb.deb
       - name: Upload build output

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,7 @@
 name: Build makedeb
 on:
  pull_request:
+ push:
 
 jobs:
   build:
@@ -23,7 +24,6 @@ jobs:
          sudo apt install makedeb-alpha -y
       - name: Generate PKGBUILD and build with makedeb
         run: |
-          cd makedeb
           sudo apt update && sudo apt install -y git jq
           cd PKGBUILD
           ./pkgbuild.sh > PKGBUILD
@@ -54,4 +54,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: makedeb-native-build
-          path: "*.deb"
+          path: "../*.deb"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          path: "makedeb"
       - name: Generate PKGBUILD and build with makedeb
         run: |
           sudo chown -R makedeb:makedeb .

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,25 @@
+name: Build makedeb
+on:
+ pull_request:
+   branches:
+     - main
+ push:
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    container:
+      image: proget.hunterwittenborn.com/docker/makedeb/makedeb:ubuntu-focal
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Generate PKGBUILD and build with makedeb
+        run: |
+          sudo chown -R makedeb:makedeb .
+          sudo apt update && sudo apt install -y git jq
+          cd PKGBUILD
+          ./pkgbuild.sh > PKGBUILD
+          PACMAN='/usr/bin/true' makedeb -s --no-confirm
+        env:
+          TARGET: local
+          RELEASE: alpha

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,11 +15,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: add VERSION env var
-        run: |
-          cat << EOF > .env
-          VERSION=$(cat .data.json | jq -r '.current_pkgver')
-          EOF
       - name: Install deps
         run: |
          sudo apt update
@@ -34,6 +29,9 @@ jobs:
           cd PKGBUILD
           ./pkgbuild.sh > PKGBUILD
           PACMAN='/usr/bin/true' makedeb -s --no-confirm
+          cat << EOF > .env
+            VERSION=$(cat .data.json | jq -r '.current_pkgver')
+          EOF
           source .env && mv makedeb-alpha_$VERSION-1_all.deb makedeb.deb
       #- name: Rename result
       #  run: source .env && mv makedeb-alpha_$VERSION-1_all.deb makedeb.deb

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,9 +11,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          path: "makedeb"
+          path: "/home/makedeb/makedeb"
       - name: Generate PKGBUILD and build with makedeb
         run: |
+          cd /home/makedeb/makedeb
           sudo chown -R makedeb:makedeb .
           sudo apt update && sudo apt install -y git jq
           cd PKGBUILD
@@ -22,6 +23,12 @@ jobs:
         env:
           TARGET: local
           RELEASE: alpha
+      - name: Upload build output
+        uses: actions/upload-artifact@v2
+        with:
+          name: makedeb-build
+          path: *.deb
+        retention-days: 7
 
   build-native:
     runs-on: ubuntu-20.04
@@ -39,3 +46,9 @@ jobs:
         run: source .env && tar -cJf ../makedeb_$VERSION.orig.tar.xz .
       - name: build makedeb using native packaging
         run: source .env && ls .. && debuild -us -uc
+      - name: Upload build output
+        uses: actions/upload-artifact@v2
+        with:
+          name: makedeb-native-build
+          path: *.deb
+        retention-days: 7

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,6 +15,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup version env var
+        run: |
+         cat << EOF > ../.env
+            VERSION=$(cat .data.json | jq -r '.current_pkgver')
+          EOF
+
       - name: Install deps
         run: |
          sudo apt update
@@ -29,10 +35,7 @@ jobs:
           cd PKGBUILD
           ./pkgbuild.sh > PKGBUILD
           PACMAN='/usr/bin/true' makedeb -s --no-confirm
-          cat << EOF > .env
-            VERSION=$(cat .data.json | jq -r '.current_pkgver')
-          EOF
-          source .env && mv makedeb-alpha_$VERSION-1_all.deb makedeb.deb
+          source ../.env && mv makedeb-alpha_$VERSION-1_all.deb makedeb.deb
       #- name: Rename result
       #  run: source .env && mv makedeb-alpha_$VERSION-1_all.deb makedeb.deb
       - name: Upload build output

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,11 +29,13 @@ jobs:
           cd PKGBUILD
           ./pkgbuild.sh > PKGBUILD
           PACMAN='/usr/bin/true' makedeb -s --no-confirm
+      - name: Rename result
+        run: mv *.deb makedeb.deb
       - name: Upload build output
         uses: actions/upload-artifact@v2
         with:
           name: makedeb-build
-          path: "*.deb"
+          path: "makedeb.deb"
 
   build-native:
     runs-on: ubuntu-20.04
@@ -51,8 +53,10 @@ jobs:
         run: source .env && tar -cJf ../makedeb_$VERSION.orig.tar.xz .
       - name: build makedeb using native packaging
         run: source .env && ls .. && debuild -us -uc
+      - name: Move artifact to current dir
+        run: mv -v ../*.deb ./makedeb.deb
       - name: Upload build output
         uses: actions/upload-artifact@v2
         with:
           name: makedeb-native-build
-          path: "../*.deb"
+          path: "makedeb.deb"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,7 +3,6 @@ on:
  pull_request:
    branches:
      - main
- push:
 
 jobs:
   build:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,14 +31,12 @@ jobs:
          sudo apt install makedeb-alpha -y
       - name: Generate PKGBUILD and build with makedeb
         run: |
-          cat << EOF > ../.env
-            VERSION=$(cat .data.json | jq -r '.current_pkgver')
-          EOF
+          git tag -f "v$(cat .data.json | jq -r '.current_pkgver + "-" + .current_pkgrel')-alpha"
           sudo apt update && sudo apt install -y git jq
           cd PKGBUILD
           ./pkgbuild.sh > PKGBUILD
           PACMAN='/usr/bin/true' makedeb -s --no-confirm
-          source ../.env && mv makedeb-alpha_$VERSION-1_all.deb makedeb.deb
+          mv makedeb-alpha_$VERSION-1_all.deb makedeb.deb
       #- name: Rename result
       #  run: source .env && mv makedeb-alpha_$VERSION-1_all.deb makedeb.deb
       - name: Upload build output

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           name: makedeb-build
           path: "*.deb"
-        retention-days: 7
 
   build-native:
     runs-on: ubuntu-20.04
@@ -51,4 +50,3 @@ jobs:
         with:
           name: makedeb-native-build
           path: "*.deb"
-        retention-days: 7

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,13 +8,19 @@ jobs:
     env:
       TARGET: local
       RELEASE: alpha
-    container:
-      image: sardine123/makedeb-github-ci:ubuntu-focal
+#    container:
+#      image: sardine123/makedeb-github-ci:ubuntu-focal
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          path: "makedeb"
+      - name: Install deps
+        run: |
+         sudo apt update
+         DEBIAN_FRONTEND=noninteractive sudo apt install wget gpg sudo -y
+         wget -qO - "https://proget.hunterwittenborn.com/debian-feeds/makedeb.pub" | gpg --dearmor | tee /usr/share/keyrings/makedeb-archive-keyring.gpg 1> /dev/null
+         echo "deb [signed-by=/usr/share/keyrings/makedeb-archive-keyring.gpg arch=all] https://proget.hunterwittenborn.com/ makedeb main" | tee /etc/apt/sources.list.d/makedeb.list
+         sudo apt update
+         sudo apt install makedeb-alpha -y
       - name: Generate PKGBUILD and build with makedeb
         run: |
           cd makedeb

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,6 +36,7 @@ jobs:
           cd PKGBUILD
           ./pkgbuild.sh > PKGBUILD
           PACMAN='/usr/bin/true' makedeb -s --no-confirm
+          ls -alt
           mv makedeb-alpha_$(cat .data.json | jq -r '.current_pkgver + "-" + .current_pkgrel')_all.deb makedeb.deb
       #- name: Rename result
       #  run: source .env && mv makedeb-alpha_$VERSION-1_all.deb makedeb.deb

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Install deps
         run: |
          sudo apt update

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,11 +15,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup version env var
-        run: |
-         cat << EOF > ../.env
-            VERSION=$(cat .data.json | jq -r '.current_pkgver')
-          EOF
+#      - name: Setup version env var
+#        run: |
+#         cat << EOF > ../.env
+#            VERSION=$(cat .data.json | jq -r '.current_pkgver')
+#          EOF
 
       - name: Install deps
         run: |
@@ -31,6 +31,9 @@ jobs:
          sudo apt install makedeb-alpha -y
       - name: Generate PKGBUILD and build with makedeb
         run: |
+          cat << EOF > ../.env
+            VERSION=$(cat .data.json | jq -r '.current_pkgver')
+          EOF
           sudo apt update && sudo apt install -y git jq
           cd PKGBUILD
           ./pkgbuild.sh > PKGBUILD

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,3 +22,20 @@ jobs:
         env:
           TARGET: local
           RELEASE: alpha
+
+  build-native:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: sudo apt update && sudo apt install -y git gnupg pbuilder ubuntu-dev-tools apt-file python3 python3-pip debhelper asciidoctor jq
+      - name: add VERSION env var
+        run: |
+          cat << EOF > .env
+          VERSION=$(cat .data.json | jq -r '.current_pkgver')
+          EOF
+      - name: tar directory into source tarball
+        run: source .env && tar -cJf ../makedeb_$VERSION.orig.tar.xz .
+      - name: build makedeb using native packaging
+        run: source .env && ls .. && debuild -us -uc

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,7 +37,7 @@ jobs:
           ./pkgbuild.sh > PKGBUILD
           PACMAN='/usr/bin/true' makedeb -s --no-confirm
           ls -alt
-          mv makedeb-alpha_$(cat ../.data.json | jq -r '.current_pkgver + "-" + .current_pkgrel')_all.deb makedeb.deb
+          mv -v makedeb-alpha_$(cat ../.data.json | jq -r '.current_pkgver + "-" + .current_pkgrel')_all.deb ../makedeb.deb
       #- name: Rename result
       #  run: source .env && mv makedeb-alpha_$VERSION-1_all.deb makedeb.deb
       - name: Upload build output

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,7 +37,7 @@ jobs:
           ./pkgbuild.sh > PKGBUILD
           PACMAN='/usr/bin/true' makedeb -s --no-confirm
           ls -alt
-          mv makedeb-alpha_$(cat .data.json | jq -r '.current_pkgver + "-" + .current_pkgrel')_all.deb makedeb.deb
+          mv makedeb-alpha_$(cat ../.data.json | jq -r '.current_pkgver + "-" + .current_pkgrel')_all.deb makedeb.deb
       #- name: Rename result
       #  run: source .env && mv makedeb-alpha_$VERSION-1_all.deb makedeb.deb
       - name: Upload build output

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,19 +7,11 @@ jobs:
     env:
       TARGET: local
       RELEASE: alpha
-#    container:
-#      image: sardine123/makedeb-github-ci:ubuntu-focal
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
-#      - name: Setup version env var
-#        run: |
-#         cat << EOF > ../.env
-#            VERSION=$(cat .data.json | jq -r '.current_pkgver')
-#          EOF
 
       - name: Install deps
         run: |
@@ -38,8 +30,6 @@ jobs:
           PACMAN='/usr/bin/true' makedeb -s --no-confirm
           ls -alt
           mv -v makedeb-alpha_$(cat ../.data.json | jq -r '.current_pkgver + "-" + .current_pkgrel')_all.deb ../makedeb.deb
-      #- name: Rename result
-      #  run: source .env && mv makedeb-alpha_$VERSION-1_all.deb makedeb.deb
       - name: Upload build output
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,8 +1,6 @@
 name: Build makedeb
 on:
  pull_request:
-   branches:
-     - main
 
 jobs:
   build:


### PR DESCRIPTION
Adds Github CI to every PR.

The CI automagically runs a native Debian build and a build using makedeb itself.
