### PR TITLE
Changed `apt-get` for `apt` in `makedeb.sh`

### DIFF
--- a/src/makedeb.sh
+++ b/src/makedeb.sh
@@ -170,7 +170,7 @@ if [[ "${target_os}" == "debian" ]] && [[ ${INSTALL} == "TRUE" ]]; then
 
   apt_installation_string="$(echo "${pkgname[@]}" | sed 's| |, |g')"
   msg "Installing ${apt_installation_string}..."
-  sudo apt-get reinstall "${apt_args[@]}" -- "${apt_installation_list[@]}"
+  sudo apt reinstall "${apt_args[@]}" -- "${apt_installation_list[@]}"
 
   if (( "${makedeb_args["as-deps"]}" )); then
     sudo apt-mark auto -- "${pkgname[@]}" 1> /dev/null


### PR DESCRIPTION
> Swapped `apt-get` for `apt`

I'm fairly sure `apt-get` cannot install a `.deb` file, but `apt` can. I found this to be an issue at least when trying to install [`stoke`](https://mpr.hunterwittenborn.com/packages/stoke-git), and I'm fairly sure the problem lies here, and not with stoke.