### PR TITLE
Add unit tests

### DIFF
--- a/.data.json
+++ b/.data.json
@@ -1,5 +1,5 @@
 {
-    "current_pkgver": "8.5.10",
+    "current_pkgver": "8.6.0",
     "current_pkgrel": "1",
     "makedeb_man_epoch": "1635393570",
     "pkgbuild_man_epoch": "1635393570"

--- a/.drone/scripts/run-unit-tests.sh
+++ b/.drone/scripts/run-unit-tests.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/bash
+set -ex
+
+cd test/
+bats prepare/
+bats test/

--- a/.drone/scripts/run-unit-tests.sh
+++ b/.drone/scripts/run-unit-tests.sh
@@ -3,4 +3,4 @@ set -ex
 
 cd test/
 bats prepare/
-bats test/
+bats tests/

--- a/.drone/scripts/run-unit-tests.sh
+++ b/.drone/scripts/run-unit-tests.sh
@@ -3,4 +3,4 @@ set -ex
 
 cd test/
 bats prepare/
-bats tests/
+bats tests/pkgmaint-scripts.bats

--- a/.drone/scripts/run-unit-tests.sh
+++ b/.drone/scripts/run-unit-tests.sh
@@ -3,4 +3,4 @@ set -ex
 
 cd test/
 bats prepare/
-bats tests/pkgmaint-scripts.bats
+bats tests/

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,21 +12,12 @@ jobs:
       - name: Install needed dependencies
         run: |
           export DEBIAN_FRONTEND=noninteractive
-          sudo -E apt-get install tzdata git jq sudo sed ubuntu-dev-tools debhelper asciidoctor -y
+          sudo -E apt-get install tzdata git jq sudo sed ubuntu-dev-tools debhelper asciidoctor bats -y
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Build
-        run: |
-          export release_type=alpha pkgname=makedeb-alpha
-          .drone/scripts/build-native.sh
-      - name: Move built .deb to current directory
-        run: mv -v ../*.deb ./makedeb.deb
-      - name: Upload build output
-        uses: actions/upload-artifact@v2
-        with:
-          name: makedeb-native-build
-          path: "makedeb.deb"
+      - name: Run unit tests
+        run: .drone/scripts/run-unit-tests.sh
 
 # vim: expandtab ts=2 sw=2

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-makedeb (8.5.10-1) unstable; urgency=medium
+makedeb (8.6.0-1) unstable; urgency=medium
 
   * Initial release (Closes: #998039).
 
- -- Leo Puvilland <leo@craftcat.dev>  Tue, 14 Dec 2021 23:33:20 -0600
+ -- Leo Puvilland <leo@craftcat.dev>  Wed, 15 Dec 2021 23:48:36 -0600

--- a/test/files/TEMPLATE.PKGBUILD
+++ b/test/files/TEMPLATE.PKGBUILD
@@ -25,6 +25,16 @@ source=$${source}
 sha256sums=$${sha256sums}
 noextract=$${noextract}
 
+focal_depends=$${focal_depends}
+focal_optdepends=$${focal_depends}
+focal_makedepends=$${focal_makedepends}
+focal_checkdepends=$${focal_checkdepends}
+focal_conflicts=$${focal_conflicts}
+focal_provides=$${focal_provides}
+focal_replaces=$${focal_replaces}
+focal_source=$${focal_source}
+focal_sha256sums=$${focal_sha256sums}
+
 prepare() {
     true
 }

--- a/test/files/TEMPLATE.PKGBUILD
+++ b/test/files/TEMPLATE.PKGBUILD
@@ -1,0 +1,46 @@
+# Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
+pkgbase=$${pkgbase}
+pkgname=$${pkgname}
+pkgver=$${pkgver}
+pkgrel=$${pkgrel}
+epoch=$${epoch}
+pkgdesc=$${pkgdesc}
+arch=$${arch}
+depends=$${depends}
+optdepends=$${optdepends}
+makedepends=$${makedepends}
+checkdepends=$${checkdepends}
+conflicts=$${conflicts}
+provides=$${provides}
+replaces=$${replaces}
+install=$${install}
+url=$${url}
+control_fields=$${control_fields}
+preinst=$${preinst}
+postinst=$${postinst}
+prerm=$${prerm}
+postrm=$${postrm}
+options=$${options}
+source=$${source}
+sha256sums=$${sha256sums}
+noextract=$${noextract}
+
+prepare() {
+    true
+}
+
+pkgver() {
+    echo "1.0.0"
+}
+
+build() {
+    true
+}
+
+check() {
+    true
+}
+
+package() {
+    true
+}

--- a/test/prepare/prepare.bats
+++ b/test/prepare/prepare.bats
@@ -10,6 +10,6 @@ setup() {
 
 @test "install makedeb from native-packaged version" {
     cd ../../
-    version="$(cat .data.json | jq -r '.current_pkgver + "-" .current_pkgrel')"
+    version="$(cat .data.json | jq -r '.current_pkgver + "-" + .current_pkgrel')"
     sudo -n DEBIAN_FRONTEND=noninteractive apt-get reinstall "./${pkgname}_${version}_all.deb" -y
 }

--- a/test/prepare/prepare.bats
+++ b/test/prepare/prepare.bats
@@ -1,0 +1,15 @@
+setup() {
+    cd "${BATS_TEST_DIRNAME}"
+    export pkgname="${pkgname:-makedeb-alpha}" release_type="${release_type:-alpha}"
+}
+
+@test "build makedeb from native-packaged version" {
+    cd ../../
+    .drone/scripts/build-native.sh
+}
+
+@test "install makedeb from native-packaged version" {
+    cd ../../
+    version="$(cat .data.json | jq -r '.current_pkgver + "-" .current_pkgrel')"
+    sudo -n DEBIAN_FRONTEND=noninteractive apt-get reinstall "./${pkgname}_${version}_all.deb" -y
+}

--- a/test/tests/arch.bats
+++ b/test/tests/arch.bats
@@ -1,0 +1,32 @@
+load ../util/util
+
+@test "correct arch - all allowed characters" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch x86_64
+    pkgbuild clean
+    makedeb -d
+}
+
+@test "incorrect arch - use any with another architecture" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any x86_64
+    pkgbuild clean
+    run makedeb -d
+    [[ "${status}" == "12" ]]
+    [[ "${output}" == "[!] Can not use 'any' architecture with other architectures" ]]
+}
+
+@test "incorrect arch - unknown architecture" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch there_is_no_way_this_architecture_exists
+    pkgbuild clean
+    run makedeb -d
+    [[ "${status}" == "12" ]]
+    [[ "${output}" == "[!] testpkg is not available for the 'x86_64' architecture." ]]
+}

--- a/test/tests/arg_check.bats
+++ b/test/tests/arg_check.bats
@@ -37,6 +37,7 @@ load ../util/util
 }
 
 @test "run makedeb with long options and grouped short options" {
+    skip "THIS WON'T PASS DUE TO A BUG IN MAKEDEB."
     sudo_check
     pkgbuild string pkgname test-pkg
     pkgbuild string pkgver 1.0.0

--- a/test/tests/arg_check.bats
+++ b/test/tests/arg_check.bats
@@ -43,7 +43,7 @@ load ../util/util
     pkgbuild string pkgrel 1
     pkgbuild array arch any
     pkgbuild clean
-    sudo makedeb -dr --install
+    makedeb -dr --install
 }
 
 @test "run makedeb with invalid singled short option" {

--- a/test/tests/arg_check.bats
+++ b/test/tests/arg_check.bats
@@ -1,0 +1,65 @@
+load ../util/util
+
+@test "run makedeb with singled short options" {
+    pkgbuild string pkgname test-pkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    makedeb -d -r
+}
+
+@test "run makedeb with singled long options" {
+    pkgbuild string pkgname test-pkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    makedeb --no-deps --rm-deps
+}
+
+@test "run makedeb with grouped short options" {
+    pkgbuild string pkgname test-pkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    makedeb -dr
+}
+
+@test "run makedeb with long options and singled short options" {
+    pkgbuild string pkgname test-pkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    makedeb -d --rm-deps
+}
+
+@test "run makedeb with long options and grouped short options" {
+    sudo_check
+    pkgbuild string pkgname test-pkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    sudo makedeb -dr --install
+}
+
+@test "run makedeb with invalid singled short option" {
+    pkgbuild string pkgname test-pkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    run ! makedeb -d -z
+}
+
+@test "run makedeb with invalid grouped short option" {
+    pkgbuild string pkgname test-pkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    run ! makedeb -dz
+}

--- a/test/tests/checkdepends.bats
+++ b/test/tests/checkdepends.bats
@@ -1,0 +1,45 @@
+load ../util/util
+
+@test "correct checkdepends - all valid characters" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array checkdepends 'bats>0' 'bash'
+    pkgbuild clean
+    makedeb -d
+}
+
+@test "correct checkdepends - install missing dependencies" {
+    sudo_check
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array checkdepends 'zsh' 'yash>=0.0.1'
+    pkgbuild clean
+    makedeb -s --no-confirm
+}
+
+@test "correct checkdepends - don't add to 'Depends' in control file" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array checkdepends 'zsh' 'yash>=0.0.1'
+    pkgbuild clean
+    makedeb -d
+    [[ "$(cat pkg/testpkg/DEBIAN/control | grep 'Depends:')" == "" ]]
+}
+
+@test "incorrect checkdepends - invalid dependency prefix" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array checkdepends 'z!bats'
+    pkgbuild clean
+    run makedeb -d
+    [[ "${status}" == "12" ]]
+    [[ "${output}" == "[!] checkdepends contains invalid characters: '!'" ]]
+}

--- a/test/tests/checkdepends.bats
+++ b/test/tests/checkdepends.bats
@@ -11,6 +11,7 @@ load ../util/util
 }
 
 @test "correct checkdepends - install missing dependencies" {
+    skip "THIS IS CURRENTLY FAILING DUE TO A BUG IN MAKEDEB"
     sudo_check
     pkgbuild string pkgname testpkg
     pkgbuild string pkgver 1.0.0

--- a/test/tests/conflicts.bats
+++ b/test/tests/conflicts.bats
@@ -1,0 +1,15 @@
+load ../util/util
+
+@test "correct depends - all valid characters" {
+    skip "THIS WON'T CURRENTLY PASS DUE TO A BUG IN MAKEDEB."
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array conflicts 'make>0' 'asciidoctor'
+    pkgbuild clean
+    makedeb -s --install --no-confirm
+    [[ "$(cat pkg/testpkg/DEBIAN/control | grep '^Conflicts')" == "Conflicts: make (>> 0), asciidoctor" ]]
+    run ! type make
+    run ! type asciidoctor
+}

--- a/test/tests/depends.bats
+++ b/test/tests/depends.bats
@@ -1,0 +1,47 @@
+load ../util/util
+
+@test "correct depends - all valid characters" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array depends 'bats>0' 'bash'
+    pkgbuild clean
+    makedeb -d
+}
+
+@test "correct depends - install missing dependencies" {
+    sudo_check
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array depends 'zsh' 'yash>=0.0.1'
+    pkgbuild clean
+    makedeb -s --no-confirm
+}
+
+@test "correct depends - valid dependency prefixes" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array depends 'p!bats>0' 'bash'
+    pkgbuild clean
+    makedeb -d
+
+    [[ "$(cat pkg/testpkg/DEBIAN/control | grep '^Pre-Depends')" == "Pre-Depends: bats (>> 0)" ]]
+    [[ "$(cat pkg/testpkg/DEBIAN/control | grep '^Depends:')" == "Depends: bash" ]]
+}
+
+@test "incorrect depends - invalid dependency prefix" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch x86_64
+    pkgbuild array depends 'z!bats'
+    pkgbuild clean
+    run makedeb -d
+    [[ "${status}" == "12" ]]
+    [[ "${output}" == "[!] depends contains an invalid prefix: 'z!'" ]]
+}

--- a/test/tests/depends.bats
+++ b/test/tests/depends.bats
@@ -11,6 +11,7 @@ load ../util/util
 }
 
 @test "correct depends - install missing dependencies" {
+    skip "THIS IS CURRENTLY NOT WORKING DUE TO A BUG IN MAKEDEB."
     sudo_check
     pkgbuild string pkgname testpkg
     pkgbuild string pkgver 1.0.0

--- a/test/tests/epoch.bats
+++ b/test/tests/epoch.bats
@@ -1,0 +1,47 @@
+load ../util/util
+
+@test "correct epoch - all allowed characters" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild string epoch 200
+    pkgbuild array arch any
+    pkgbuild clean
+    makedeb -d
+}
+
+@test "incorrect epoch - negative number" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild string epoch '-50'
+    pkgbuild array arch any
+    pkgbuild clean
+    run makedeb -d
+    [[ "${status}" == "12" ]]
+    [[ "${output}" == '[!] epoch must be an integer, not -50.' ]]
+}
+
+@test "incorrect epoch - decimal" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild string epoch 20.1
+    pkgbuild array arch any
+    pkgbuild clean
+    run makedeb -d
+    [[ "${status}" == "12" ]]
+    [[ "${output}" == '[!] epoch must be an integer, not 20.1.' ]]
+}
+
+@test "incorrect epoch - letter" {
+    skip "THIS IS FAILING DUE TO A BUG IN MAKEDEB."
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild string epoch a5
+    pkgbuild array arch any
+    pkgbuild clean
+    run makedeb -d
+    [[ "${status}" == "12" ]]
+}

--- a/test/tests/functions.bats
+++ b/test/tests/functions.bats
@@ -1,0 +1,45 @@
+load ../util/util
+
+@test "correct prepare()" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    makedeb -d
+}
+
+@test "incorrect prepare() - bad exit code" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    remove_function "prepare"
+    echo -e '\nprepare() { false; }' >> PKGBUILD
+    pkgbuild clean
+    run makedeb -d
+    [[ "${status}" == "4" ]]
+}
+
+@test "incorrect pkgver() - incorrect syntax for returned version" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    remove_function "pkgver"
+    echo -e '\npkgver() { echo "asdf me"; }' >> PKGBUILD
+    pkgbuild clean
+    run makedeb -d
+    [[ "${status}" == "12" ]]
+}
+
+@test "incorrect package() - missing 'package()' function" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    remove_function "package"
+    pkgbuild clean
+    run makedeb -d
+    [[ "${status}" == "12" ]]
+}

--- a/test/tests/license.bats
+++ b/test/tests/license.bats
@@ -1,0 +1,11 @@
+load ../util/util
+
+@test "correct license - all valid characters" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array license "custom: It's a % whaccky : what is this ? mess#!"
+    pkgbuild clean
+    makedeb -d
+}

--- a/test/tests/makedepends.bats
+++ b/test/tests/makedepends.bats
@@ -1,0 +1,45 @@
+load ../util/util
+
+@test "correct makedepends - all valid characters" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array makedepends 'bats>0' 'bash'
+    pkgbuild clean
+    makedeb -d
+}
+
+@test "correct makedepends - install missing dependencies" {
+    sudo_check
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array makedepends 'zsh' 'yash>=0.0.1'
+    pkgbuild clean
+    makedeb -s --no-confirm
+}
+
+@test "correct makedepends - don't add to 'Depends' in control file" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array makedepends 'zsh' 'yash>=0.0.1'
+    pkgbuild clean
+    makedeb -d
+    [[ "$(cat pkg/testpkg/DEBIAN/control | grep 'Depends:')" == "" ]]
+}
+
+@test "incorrect makedepends - invalid dependency prefix" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array makedepends 'z!bats'
+    pkgbuild clean
+    run makedeb -d
+    [[ "${status}" == "12" ]]
+    [[ "${output}" == "[!] makedepends contains invalid characters: '!'" ]]
+}

--- a/test/tests/makedepends.bats
+++ b/test/tests/makedepends.bats
@@ -11,6 +11,7 @@ load ../util/util
 }
 
 @test "correct makedepends - install missing dependencies" {
+    skip "THIS IS CURRENTLY FAILING DUE TO A BUG IN MAKEDEB."
     sudo_check
     pkgbuild string pkgname testpkg
     pkgbuild string pkgver 1.0.0

--- a/test/tests/misc.bats
+++ b/test/tests/misc.bats
@@ -1,0 +1,46 @@
+load ../util/util
+
+@test "correct - build and install a package" {
+    skip "THIS WON'T PASS DUE TO THE '-i' FLAG ISSUE IN MAKEDEB"
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    makedeb -d
+}
+
+@test "correct - set dependencies from a distro-dependency variable" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array depends 'gimp'
+    pkgbuild array focal_depends 'krita'
+    pkgbuild clean
+    makedeb -d
+    [[ "$(cat pkg/testpkg/DEBIAN/control | grep 'Depends:')" == "Depends: krita" ]]
+}
+
+@test "correct - generate SRCINFO and control files" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    makedeb --print-srcinfo
+    makedeb --print-control
+}
+
+@test "incorrect - set distro-specific sources without distro-specific hashsums" {
+    skip "THIS ISN'T WORKING DUE TO AN ISSUE IN MAKEDEB."
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array source 'https://mpr.hunterwittenborn.com'
+    pkgbuild array focal_source 'https://proget.hunterwittenborn.com'
+    pkgbuild array sha256sums 'SKIP'
+    pkgbuild clean
+    makedeb -d
+}

--- a/test/tests/optdepends.bats
+++ b/test/tests/optdepends.bats
@@ -1,0 +1,48 @@
+load ../util/util
+
+@test "correct optdepends - all valid characters" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array optdepends 'bats>0: good shell testing framework' 'bash: king of shell'
+    pkgbuild clean
+    makedeb -d
+}
+
+@test "correct optdepends - install missing dependencies" {
+    skip "THIS IS CURRENTLY NOT WORKING DUE TO A BUG IN MAKEDEB."
+    sudo_check
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array optdepends 'zsh: adding a reason so we can see if makedeb strips it before adding it to the control file' 'yash>=0.0.1'
+    pkgbuild clean
+    makedeb -s --no-confirm
+}
+
+@test "correct optdepends - valid dependency prefixes" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array optdepends 'r!bats>0' 's!bash' 'yash'
+    pkgbuild clean
+    makedeb -d
+
+    [[ "$(cat pkg/testpkg/DEBIAN/control | grep 'Suggests:')" == "Suggests: bash, yash" ]]
+    [[ "$(cat pkg/testpkg/DEBIAN/control | grep 'Recommends:')" == "Recommends: bats (>> 0)" ]]
+}
+
+@test "incorrect optdepends - invalid dependency prefix" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch x86_64
+    pkgbuild array optdepends 'z!bats'
+    pkgbuild clean
+    run makedeb -d
+    [[ "${status}" == "12" ]]
+    [[ "${output}" == "[!] optdepends contains an invalid prefix: 'z!'" ]]
+}

--- a/test/tests/options.bats
+++ b/test/tests/options.bats
@@ -1,0 +1,23 @@
+load ../util/util
+
+@test "correct options - valid options" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array options '!zipman'
+    pkgbuild clean
+    makedeb -d
+}
+
+@test "incorrect options - invalid options" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array options '!no_way_this_option_exists'
+    pkgbuild clean
+    run makedeb -d
+    [[ "${status}" == "12" ]]
+    [[ "${output}" == "[!] options array contains unknown option '!no_way_this_option_exists'" ]]
+}

--- a/test/tests/pkgbase.bats
+++ b/test/tests/pkgbase.bats
@@ -1,0 +1,78 @@
+load ../util/util
+
+@test "correct pkgbase - lowercase letters" {
+    pkgbuild string pkgbase testpkg
+    pkgbuild string pkgname test-pkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    makedeb -d
+}
+
+@test "correct pkgbase - digits and minus sign" {
+    pkgbuild string pkgbase test-123
+    pkgbuild string pkgname test-pkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    run makedeb -d
+}
+
+@test "correct pkgbase - plus sign" {
+    pkgbuild string pkgbase 'test-1+3'
+    pkgbuild string pkgname test-pkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    run makedeb -d
+}
+
+@test "correct pkgbase - period" {
+    pkgbuild string pkgbase 'test-1.3'
+    pkgbuild string pkgname test-pkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    run makedeb -d
+}
+
+@test "incorrect pkgbase - capital letters" {
+    skip "DOESN'T FAIL PROPERLY DUE TO BUG IN MAKEDEB CODE"
+    pkgbuild string pkgbase test-Akg
+    pkgbuild string pkgname test-pkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    run makedeb -d
+    [[ "${status}" == "12" ]]
+    [[ "${output}" == "something???" ]]
+}
+
+@test "incorrect pkgbase - invalid character" {
+    pkgbuild string pkgbase 'test-%kg'
+    pkgbuild string pkgname test-pkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    run makedeb -d
+    [[ "${status}" == "12" ]]
+    [[ "${output}" == "[!] pkgbase contains invalid characters: '%'" ]]
+}
+    
+@test "incorrect pkgbase - array" {
+    pkgbuild array pkgbase test-pkg test-pkg2
+    pkgbuild string pkgname test-pkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    run makedeb -d
+    [[ "${status}" == "12" ]]
+    [[ "${output}" == '[!] pkgbase should not be an array' ]]
+}

--- a/test/tests/pkgdesc.bats
+++ b/test/tests/pkgdesc.bats
@@ -1,0 +1,22 @@
+load ../util/util
+
+@test "correct pkgdesc - all allowed characters" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild string pkgdesc "Normal package description: on the package"
+    pkgbuild array arch any
+    pkgbuild clean
+    makedeb -d
+}
+
+@test "incorrect pkgdesc - only whitespace" {
+    skip "THIS WON'T CURRENT FAIL DUE TO A BUG IN MAKEDEB"
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild string pkgdesc "     "
+    pkgbuild array arch any
+    pkgbuild clean
+    makedeb -d
+}

--- a/test/tests/pkgmaint-scripts.bats
+++ b/test/tests/pkgmaint-scripts.bats
@@ -1,0 +1,33 @@
+load ../util/util
+
+@test "correct preinst - valid path" {
+    touch file
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild string preinst './file'
+    pkgbuild clean
+    makedeb -d
+
+    ar xf testpkg_1.0.0-1_all.deb
+    mapfile -t files < <(tar tf control.tar.gz)
+    expected_files=('./control' './preinst')
+
+    [[ "${#files[@]}" == "${#expected_files[@]}" ]]
+
+    for i in $(seq $(( "${#files[@]}" - 1 )) ); do
+        [[ "${files[$i]}" == "${expected_files[$i]}" ]]
+    done
+}
+
+@test "incorrect preinst - invalid path" {
+    skip "THIS TEST WON'T PASS DUE TO THE 'colorize' BUG IN MAKEDEB"
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild string preinst './file'
+    pkgbuild clean
+    makedeb -d
+}

--- a/test/tests/pkgmaint-scripts.bats
+++ b/test/tests/pkgmaint-scripts.bats
@@ -16,7 +16,7 @@ load ../util/util
 
     [[ "${#files[@]}" == "${#expected_files[@]}" ]]
 
-    for i in $(seq $(( "${#files[@]}" - 1 )) ); do
+    for i in $(seq 0 $(( "${#files[@]}" - 1 )) ); do
         [[ "${files[$i]}" == "${expected_files[$i]}" ]]
     done
 }

--- a/test/tests/pkgmaint-scripts.bats
+++ b/test/tests/pkgmaint-scripts.bats
@@ -11,13 +11,10 @@ load ../util/util
     makedeb -d
 
     ar xf testpkg_1.0.0-1_all.deb
-    mapfile -t files < <(tar tf control.tar.gz)
-    expected_files=('./control' './preinst')
+    mapfile -t files < <(tar tf control.tar.gz | sort -V)
+    mapfile -t expected_files < <(printf '%s\n' './control' './preinst' | sort -V)
 
     [[ "${#files[@]}" == "${#expected_files[@]}" ]]
-    
-    echo "${files[@]}"
-    echo "${expected_files[@]}"
 
     for i in $(seq 0 $(( "${#files[@]}" - 1 )) ); do
         [[ "${files[$i]}" == "${expected_files[$i]}" ]]

--- a/test/tests/pkgmaint-scripts.bats
+++ b/test/tests/pkgmaint-scripts.bats
@@ -15,6 +15,9 @@ load ../util/util
     expected_files=('./control' './preinst')
 
     [[ "${#files[@]}" == "${#expected_files[@]}" ]]
+    
+    echo "${files[@]}"
+    echo "${expected_files[@]}"
 
     for i in $(seq 0 $(( "${#files[@]}" - 1 )) ); do
         [[ "${files[$i]}" == "${expected_files[$i]}" ]]

--- a/test/tests/pkgname.bats
+++ b/test/tests/pkgname.bats
@@ -1,0 +1,60 @@
+load ../util/util
+
+@test "correct pkgname - lowercase letters" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    makedeb -d
+}
+
+@test "correct pkgname - digits and minus sign" {
+    pkgbuild string pkgname test-pkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    run makedeb -d
+}
+
+@test "correct pkgname - plus sign" {
+    pkgbuild string pkgname test-pkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    run makedeb -d
+}
+
+@test "correct pkgname - period" {
+    pkgbuild string pkgname test-pkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    run makedeb -d
+}
+
+@test "incorrect pkgname - capital letters" {
+    skip "DOESN'T FAIL PROPERLY DUE TO BUG IN MAKEDEB CODE"
+    pkgbuild string pkgname test-pkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    run makedeb -d
+    [[ "${status}" == "12" ]]
+    [[ "${output}" == "something???" ]]
+}
+
+@test "incorrect pkgname - disallowed character" {
+    pkgbuild string pkgname test-pkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    run makedeb -d
+    [[ "${status}" == "12" ]]
+    [[ "${output}" == "[!] pkgbase contains invalid characters: '%'" ]]
+}

--- a/test/tests/pkgname.bats
+++ b/test/tests/pkgname.bats
@@ -49,12 +49,13 @@ load ../util/util
 }
 
 @test "incorrect pkgname - disallowed character" {
-    pkgbuild string pkgname test-pkg
+    pkgbuild string pkgbase testpkg
+    pkgbuild string pkgname 'testp%kg'
     pkgbuild string pkgver 1.0.0
     pkgbuild string pkgrel 1
     pkgbuild array arch any
     pkgbuild clean
     run makedeb -d
     [[ "${status}" == "12" ]]
-    [[ "${output}" == "[!] pkgbase contains invalid characters: '%'" ]]
+    [[ "${output}" == "[!] pkgname contains invalid characters: '%'" ]]
 }

--- a/test/tests/pkgrel.bats
+++ b/test/tests/pkgrel.bats
@@ -1,0 +1,30 @@
+load ../util/util
+
+@test "correct pkgrel - all allowed characters" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    makedeb -d
+}
+
+@test "incorrect pkgrel - letter" {
+    skip "THIS WILL FAIL DUE TO THE 'colorize' BUG IN MAKEDEB."
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1a
+    pkgbuild array arch any
+    pkgbuild clean
+    makedeb -d
+}
+
+@test "incorrect pkgrel - period" {
+    skip "THIS WILL FAIL DUE TO THE 'colorize' BUG IN MAKEDEB."
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1.0
+    pkgbuild array arch any
+    pkgbuild clean
+    makedeb -d
+}

--- a/test/tests/pkgver.bats
+++ b/test/tests/pkgver.bats
@@ -1,0 +1,32 @@
+load ../util/util
+
+@test "correct pkgver - all allowed characters" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0+alpha
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    makedeb -d
+}
+
+@test "incorrect pkgver - starts with a letter" {
+    skip "THIS WON'T RUN CORRECTLY DUE TO A BUG IN MAKEDEB. DISABLE COLOR WHEN USING A NON-TERMINAL PROMPT (AS CAN BE SEEN IN 'src/makepkg/makepkg.sh')"
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver alpha1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    run makedeb -d
+    [[ "${status}" == "1" ]]
+    [[ "${output}" == '[!] pkgver 'alpha1.0.0' is not allowed to start with a digit.' ]]
+}
+
+@test "incorrect pkgver - invalid character" {
+    skip "THIS ISN'T FAILING PROPERLY DUE TO A BUG IN MAKEDEB."
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver '1.0.0+al%ha'
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild clean
+    makedeb -d
+}

--- a/test/tests/provides.bats
+++ b/test/tests/provides.bats
@@ -1,0 +1,25 @@
+load ../util/util
+
+@test "correct provides - all valid characters" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array provides 'bats=0' 'bash'
+    pkgbuild clean
+    makedeb -d
+
+    [[ "$(cat pkg/testpkg/DEBIAN/control | grep '^Provides:')" == "Provides: bats (= 0), bash" ]]
+}
+
+@test "incorrect provides - uses comparison operators" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array provides 'bats>=0'
+    pkgbuild clean
+    run makedeb -d
+    [[ "${status}" == "12" ]]
+    [[ "${output}" == '[!] provides array cannot contain comparison (< or >) operators.' ]]
+}

--- a/test/tests/replaces.bats
+++ b/test/tests/replaces.bats
@@ -1,0 +1,14 @@
+load ../util/util
+
+@test "correct replaces - all valid characters" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array replaces 'bats>=0' 'bash'
+    pkgbuild clean
+    makedeb -d
+
+    [[ "$(cat pkg/testpkg/DEBIAN/control | grep '^Replaces:')" == "Replaces: bats (>= 0), bash" ]]
+    [[ "$(cat pkg/testpkg/DEBIAN/control | grep '^Breaks:')" == "Breaks: bats (>= 0), bash" ]]
+}

--- a/test/tests/source.bats
+++ b/test/tests/source.bats
@@ -1,0 +1,73 @@
+load ../util/util
+
+@test "correct source - valid URL" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array source 'https://mpr.hunterwittenborn.com'
+    pkgbuild array sha256sums 'SKIP'
+    pkgbuild clean
+    makedeb -d
+}
+
+@test "correct source - valid hashsum" {
+    touch file
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array source "file://${PWD}/file"
+    pkgbuild array sha256sums "$(sha256sum file | awk '{print $1}')"
+    pkgbuild clean
+    makedeb -d
+}
+
+@test "correct source - noextract" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array source 'makedeb.tar.gz::https://github.com/makedeb/makedeb/archive/refs/tags/v8.5.6-1-stable.tar.gz'
+    pkgbuild array sha256sums 'SKIP'
+    pkgbuild array noextract 'makedeb.tar.gz'
+    pkgbuild clean
+    makedeb -d
+    [[ "$(find src/ -maxdepth 1 | wc -l)" == "2" ]]
+}
+
+@test "incorrect source - invalid URL" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array source 'https://mpr.hunterwittenborn.corn'
+    pkgbuild array sha256sums 'SKIP'
+    pkgbuild clean
+    run makedeb -d
+    [[ "${status}" == "1" ]]
+}
+
+@test "incorrect source - missing hashsum" {
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array source 'https://mpr.hunterwittenborn.com'
+    pkgbuild clean
+    run makedeb -d
+    [[ "${status}" == "1" ]]
+}
+
+@test "incorrect source - incorrect hashsum" {
+    touch file
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild array arch any
+    pkgbuild array source "file://${PWD}/file"
+    pkgbuild array sha256sums 'no_way_this_is_the_hashsum_man'
+    pkgbuild clean
+    run makedeb -d
+    [[ "${status}" == "1" ]]
+}

--- a/test/util/util.bash
+++ b/test/util/util.bash
@@ -3,6 +3,12 @@ setup() {
     mkdir build_area/
     cp ../files/TEMPLATE.PKGBUILD ./build_area/PKGBUILD
     cd build_area/
+
+    lsb_release() {
+        echo "focal"
+    }
+
+    export -f lsb_release
 }
 
 teardown() {
@@ -27,6 +33,18 @@ pkgbuild() {
     elif [[ "${cmd}" == "clean" ]]; then
         sed -i 's|^.*$${.*$||g' "${PKGBUILD:-PKGBUILD}"
     fi
+}
+
+remove_function() {
+    mapfile -t lines < <(cat "${PKGBUILD:-PKGBUILD}")
+
+    for i in $(seq "${#lines[@]}"); do
+        if echo "${lines[$i]}" | grep -q "${1}()"; then
+            two_more="$(( "${i}" + 3 ))"
+            sed -i "${i},${two_more}d" "${PKGBUILD:-PKGBUILD}"
+            break
+        fi
+    done
 }
 
 sudo_check() {

--- a/test/util/util.bash
+++ b/test/util/util.bash
@@ -1,0 +1,36 @@
+setup() {
+    cd "${BATS_TEST_DIRNAME}"
+    mkdir build_area/
+    cp ../files/TEMPLATE.PKGBUILD ./build_area/PKGBUILD
+    cd build_area/
+}
+
+teardown() {
+    cd ../
+    rm build_area/ -r
+}
+
+pkgbuild() {
+    cmd="${1}"
+    variable="${2}"
+    strings=("${@:3}")
+
+    if [[ "${cmd}" == "array" ]]; then
+        strings="(${strings[@]@Q})"
+        sed -i "s|\$\${${variable}}|${strings}|" "${PKGBUILD:-PKGBUILD}"
+
+    elif [[ "${cmd}" == "string" ]]; then
+        strings="${strings[@]}"
+        strings="${strings@Q}"
+        sed -i "s|\$\${${variable}}|${strings}|" "${PKGBUILD:-PKGBUILD}"
+
+    elif [[ "${cmd}" == "clean" ]]; then
+        sed -i 's|^.*$${.*$||g' "${PKGBUILD:-PKGBUILD}"
+    fi
+}
+
+sudo_check() {
+    if [[ "${BATS_SKIP_SUDO:+x}" == "x" ]]; then
+        skip "skipping, as test requires sudo"
+    fi
+}


### PR DESCRIPTION
This is much overdue considering where makedeb is at, and there's no reason to not implement them (especially in light of the recent issues that keep making it into stable).

We'll be using the [BATS](https://github.com/bats-core/bats-core) framework to manage all unit tests.

---
Quite a few of these unit tests are currently failing, and had to be manually skipped for the time being due to issues present in makedeb. The current plan is to go ahead and merge and just keep tacking on the failing unit tests (which are rooted in makedeb, not the tests themselves) as we go along (unless there's any objections to that plan).