### PR TITLE
Fixed makedeb not aborting when 'pkgver' contains invalid characters

### DIFF
--- a/.data.json
+++ b/.data.json
@@ -1,5 +1,5 @@
 {
-    "current_pkgver": "8.6.1",
+    "current_pkgver": "8.6.2",
     "current_pkgrel": "1",
     "makedeb_man_epoch": "1635393570",
     "pkgbuild_man_epoch": "1635393570"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-makedeb (8.6.1-1) unstable; urgency=medium
+makedeb (8.6.2-1) unstable; urgency=medium
 
   * Initial release (Closes: #998039).
 
- -- Leo Puvilland <leo@craftcat.dev>  Thu, 16 Dec 2021 18:10:29 -0600
+ -- Leo Puvilland <leo@craftcat.dev>  Thu, 16 Dec 2021 21:33:40 -0600

--- a/src/makedeb/main.sh
+++ b/src/makedeb/main.sh
@@ -1,20 +1,5 @@
 #!/usr/bin/env bash
 
-# Copyright 2020-2021 Hunter Wittenborn <hunter@hunterwittenborn.com>
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
 set -Ee
 
 # Values to expose to makepkg.
@@ -31,13 +16,18 @@ declare makedeb_package_version="$${MAKEDEB_VERSION}"
 declare makedeb_release_type="$${MAKEDEB_RELEASE}"
 declare makedeb_release_target="$${MAKEDEB_TARGET}"
 
+declare makedeb_package_version=git # COMP_RM
+declare makedeb_release_type=alpha # COMP_RM
+declare makedeb_release_target=apt # COMP_RM
+
 if [[ "${makedeb_release_target}" == "apt" || "${makedeb_release_target}" == "mpr" ]]; then
 	declare target_os="debian"
 elif [[ "${makedeb_release_target}" == "arch" ]]; then
 	declare target_os="arch"
 fi
 
-declare makepkg_package_name="makedeb-makepkg"
+declare MAKEPKG_PACKAGE_NAME="$(git rev-parse --show-toplevel)/src/makepkg/makepkg.sh" # COMP_RM
+declare makepkg_package_name="${MAKEPKG_PACKAGE_NAME:-makedeb-makepkg}"
 declare MAKEDEB_UTILS_DIR="./utils/" # COMP_RM
 declare makedeb_utils_dir="${MAKEDEB_UTILS_DIR:-/usr/share/makedeb/utils/}"
 
@@ -47,12 +37,20 @@ declare DIR="$(echo $PWD)"
 declare srcdir="${DIR}/src/"
 declare pkgdir="${DIR}/pkg/"
 
+declare makedeb_from_source=1 # COMP_RM
+makedeb_from_source="${makedeb_from_source:-0}"
 
 ####################
 ##  BEGIN SCRIPT  ##
 ####################
 # Get makepkg message syntax
-source "/usr/share/${makepkg_package_name}/util/message.sh"
+if (( "${makedeb_from_source}" )); then
+    export LIBRARY="$(dirname "${MAKEPKG_PACKAGE_NAME}")/functions/"
+    source "${LIBRARY}/util/message.sh"
+else
+    source "/usr/share/${makepkg_package_name}/util/message.sh"
+fi
+
 colorize
 
 # Debug logs in case a function is                       # COMP_RM

--- a/src/makepkg/functions/lint_pkgbuild/pkgver.sh
+++ b/src/makepkg/functions/lint_pkgbuild/pkgver.sh
@@ -37,18 +37,16 @@ check_pkgver() {
 		return 1
 	fi
 
-	if [[ $ver = *[[:space:]/:-]* ]]; then
-		error "$(gettext "%s is not allowed to contain colons, forward slashes, hyphens or whitespace.")" "pkgver${type:+ in $type}"
-		return 1
-	fi
+    invalid_characters="$(echo "${ver}" | sed 's|[a-z0-9.+~]||g')"
 
-	if [[ $ver = *[![:ascii:]]* ]]; then
-		error "$(gettext "%s may only contain ascii characters.")" "pkgver${type:+ in $type}"
-		return 1
-	fi
+    if [[ "${invalid_characters:+x}" == "x" ]]; then
+        error "$(gettext "%s contains invalid characters.")" "pkgver${type:+ in $type}"
+        return 1
+    fi
 
 	if ! echo "$ver" | awk -F '' '{print $1}' | grep -q '[0-9]'; then
 		error "$(gettext "%s must start with a number.")" "pkgver${type:+ in $type}"
+        return 1
 	fi
 }
 

--- a/src/makepkg/makepkg.sh
+++ b/src/makepkg/makepkg.sh
@@ -49,7 +49,6 @@ declare -r startdir="$(pwd -P)"
 declare -r makepkg_target_os='$${TARGET_OS}'
 declare -r distro_release_name="$(lsb_release -cs)"
 
-LIBRARY=${LIBRARY:-'./functions'}    # REMOVE AT PACKAGING
 LIBRARY=${LIBRARY:-'/usr/share/makedeb-makepkg'}
 
 # Options

--- a/test/tests/pkgver.bats
+++ b/test/tests/pkgver.bats
@@ -22,11 +22,12 @@ load ../util/util
 }
 
 @test "incorrect pkgver - invalid character" {
-    skip "THIS ISN'T FAILING PROPERLY DUE TO A BUG IN MAKEDEB."
     pkgbuild string pkgname testpkg
     pkgbuild string pkgver '1.0.0+al%ha'
     pkgbuild string pkgrel 1
     pkgbuild array arch any
     pkgbuild clean
-    makedeb -d
+    run makedeb -d
+    [[ "${status}" == '12' ]]
+    [[ "${output}" == "[!] pkgver contains invalid characters." ]]
 }


### PR DESCRIPTION
Changes:
- Removed license text from `src/makedeb/main.sh`, as we don't have it in all files, so I didn't really see a point in keeping it in there.
- Added some commands in makedeb to support easier development when testing locally (the changes allow the source files to be executed directly without building and installing).
- Simplified `pkgver` linting checks to only check for invalid characters and that `pkgver` starts with a number.
- Enabled unit test that this PR will fix.