### PR TITLE
Fixed tests to allow downgrades on test build of makedeb

### DIFF
--- a/test/prepare/prepare.bats
+++ b/test/prepare/prepare.bats
@@ -11,5 +11,5 @@ setup() {
 @test "install makedeb from native-packaged version" {
     cd ../../
     version="$(cat .data.json | jq -r '.current_pkgver + "-" + .current_pkgrel')"
-    sudo -n DEBIAN_FRONTEND=noninteractive apt-get reinstall "./${pkgname}_${version}_all.deb" -y
+    sudo -n DEBIAN_FRONTEND=noninteractive apt-get reinstall --allow-downgrades "./${pkgname}_${version}_all.deb" -y
 }


### PR DESCRIPTION
For some reason PRs keep complaining about makedeb trying to be downgraded. No clue why yet, but this'll at least fix the issue for now.