### PR TITLE
Renamed VCS source branch used

### DIFF
--- a/src/makepkg/functions/source/git.sh
+++ b/src/makepkg/functions/source/git.sh
@@ -125,7 +125,7 @@ extract_git() {
 	fi
 
 	if [[ $ref != "origin/HEAD" ]] || (( updating )) ; then
-		if ! git checkout --force --no-track -B makepkg "$ref" --; then
+		if ! git checkout --force --no-track -B makedeb "$ref" --; then
 			error "$(gettext "Failure while creating working copy of %s %s repo")" "${repo}" "git"
 			plainerr "$(gettext "Aborting...")"
 			exit 1


### PR DESCRIPTION
It's nothing major, but every time makedeb clones a Git repository for a VCS source it switches to the `makepkg` branch, when it makes more sense to be the `makedeb` branch.