### PR TITLE
Added shallow cloning

### DIFF
--- a/.data.json
+++ b/.data.json
@@ -1,5 +1,5 @@
 {
-    "current_pkgver": "11.0.1",
+    "current_pkgver": "12.0.0",
     "current_pkgrel": "1",
     "makedeb_man_epoch": "1635393570",
     "pkgbuild_man_epoch": "1635393570"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-makedeb (11.0.1-1) unstable; urgency=medium
+makedeb (12.0.0-1) unstable; urgency=medium
 
   * Initial release (Closes: #998039).
 
- -- Leo Puvilland <leo@craftcat.dev>  Tue, 01 Mar 2022 15:18:54 -0600
+ -- Leo Puvilland <leo@craftcat.dev>  Fri, 01 Apr 2022 17:11:55 -0500


### PR DESCRIPTION
Closes #121, this change maintains branch and tag compatibility. There's currently no option to turn it off, but that may be out of scope for this initial change.