### PR TITLE
Fix refs not getting checked out when specified in PKGBUILDs

### DIFF
--- a/.data.json
+++ b/.data.json
@@ -2,7 +2,7 @@
     "current_pkgver": "14.0.0",
     "current_pkgrel_stable": "stable",
     "current_pkgrel_beta": "beta",
-    "current_pkgrel_alpha": "alpha7",
+    "current_pkgrel_alpha": "alpha8",
     "makedeb_man_epoch": "1635393570",
     "pkgbuild_man_epoch": "1649142725"
 }

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,4 +2,4 @@ makedeb ($${pkgver}) unstable; urgency=medium
 
   * Initial release (Closes: #998039).
 
- -- Leo Puvilland <leo@craftcat.dev>  Wed, 06 Apr 2022 15:11:32 -0500
+ -- Leo Puvilland <leo@craftcat.dev>  Wed, 06 Apr 2022 16:32:41 -0500

--- a/src/functions/source/git.sh
+++ b/src/functions/source/git.sh
@@ -45,6 +45,7 @@ download_git() {
 	url=${url#git+}
 	url=${url%%#*}
 	url=${url%%\?*}
+	local fragment=$(get_uri_fragment "$netfile")
 
 	local ref=origin/HEAD
 	if [[ -n $fragment ]]; then


### PR DESCRIPTION
Before the shallow cloning implementation, we were checking out to the reference *after* cloning, but since we only clone one commit, we need to that during cloning now instead.

Likewise, we didn't set the variable to check for the specified reference until after cloning as well, which caused issues with finding references during cloning in the new implementation.