### PR TITLE
Add support for '|' characters in dependency listings

### DIFF
--- a/.data.json
+++ b/.data.json
@@ -1,5 +1,5 @@
 {
-    "current_pkgver": "14.1.2",
+    "current_pkgver": "14.1.3",
     "current_pkgrel_stable": "stable",
     "current_pkgrel_beta": "beta",
     "current_pkgrel_alpha": "alpha1",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ Note that the `[Unreleased]` section contains all changes that haven't yet made 
 - Add support for custom installing directories during builds (#61).
 - Add support for `|` characters in dependency fields.
 - Add CLI options to print makedeb-styled message (#156).
-- Add CLI option to print location of makedeb's function directory (#156).
 
 ## [14.1.2] - 2022-05-07
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ Note that the `[Unreleased]` section contains all changes that haven't yet made 
 
 ## [Unreleased]
 ### Added
-- Added support for custom installing directories during builds (#61).
+- Add support for custom installing directories during builds (#61).
+- Add support for `|` characters in dependency fields.
+- Add CLI options to print makedeb-styled message (#156).
+- Add CLI option to print location of makedeb's function directory (#156).
 
 ## [14.1.2] - 2022-05-07
 ### Fixed

--- a/man/makedeb.8.adoc
+++ b/man/makedeb.8.adoc
@@ -39,7 +39,7 @@ On the other hand, *makedeb* is NOT meant to be a replacement for package manage
   Appends the generated control file with extra fields.
 
 *-i, --install*::
-  Automatically installs the built package(s) after a successful build. This option is not available on the Arch Linux releases.
+  Automatically installs the built package(s) after a successful build.
 
 *-V, --version*::
   Prints version information and quits.
@@ -50,6 +50,9 @@ On the other hand, *makedeb* is NOT meant to be a replacement for package manage
 *-s, --sync-deps*::
   Checks for any missing build dependencies and installs them.
 
+*--lint*::
+  Lint the PKGBUILD for conformity requirements. This checks that things like variables are declared when needed, and contain valid values.
+
 *--print-control*::
   Prints a generated control file and exits.
 
@@ -59,11 +62,35 @@ On the other hand, *makedeb* is NOT meant to be a replacement for package manage
 *--skip-pgp-check*::
   Skips verification of downloaded sources against specified PGP signatures.
 
-*--verbose*::
-  Prints VERY detailed logging.
-
 *--as-deps*::
-  Marks packages installed via the *-i*/*--install* option as automatically installed. This option is not available on the Arch Linux releases.
+  Marks packages installed via the *-i*/*--install* option as automatically installed.
+
+*--allow-downgrades*::
+  Passes the *--allow-downgrades* option to *apt-get*(8) when installing build dependencies and built packages.
+
+*--no-confirm*::
+  Don't prompt before installing build dependencies or built packages. This passes the *-y* flag to *apt-get*(8) calls.
+
+*--pass-env*::
+  Passes the current user's environment variables to *sudo*(8) calls. This is needed for things like dependency installation when you want to pass the *DEBIAN_FRONTEND* environment variable to *apt-get*(8) calls.
+
+*--msg*::
+  Print a message styled in the format of running *msg* from a PKGBUILD.
+
+*--msg2*::
+  Print a message styled in the format of running *msg2* from a PKGBUILD.
+
+*--warning*::
+  Print a message styled in the format of running *warning* from a PKGBUILD.
+
+*--warning2*::
+  Print a message styled in the format of running *warning2* from a PKGBUILD.
+
+*--error*::
+  Print a message styled in the format of running *error* from a PKGBUILD.
+
+*--error2*::
+  Print a message styled in the format of running *error2* from a PKGBUILD.
 
 == EXIT STATUS
 *makedeb* exits with an exit code of 0 on success, and 1 in all other events.

--- a/po/makedeb.pot
+++ b/po/makedeb.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-25 00:50-0500\n"
+"POT-Creation-Date: 2022-05-15 16:08-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,40 +17,262 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/main.sh:160
-msgid "Cleaning up..."
+#: src/main.sh:815
+msgid "  --allow-downgrades    Allow packages to be downgraded"
 msgstr ""
 
-#: src/main.sh:198
-msgid "Entering %s environment..."
+#: src/main.sh:814
+msgid "  --as-deps             Mark built packages as automatically installed"
 msgstr ""
 
-#: src/main.sh:205 src/main.sh:304
-msgid "Starting %s()..."
+#: src/main.sh:826
+msgid "  --error               Print an error message to stderr"
 msgstr ""
 
-#: src/main.sh:211
-msgid "pkgver() generated an invalid version: %s"
+#: src/main.sh:827
+msgid "  --error2              Print an error2 message to stderr"
 msgstr ""
 
-#: src/main.sh:221
-msgid "Failed to update %s from %s to %s"
+#: src/main.sh:808
+msgid "  --lint                Link the PKGBUILD for conformity requirements"
 msgstr ""
 
-#: src/main.sh:227
-msgid "Updated version: %s"
+#: src/main.sh:822
+msgid "  --msg                 Print a msg message to stdout"
 msgstr ""
 
-#: src/main.sh:229
+#: src/main.sh:823
+msgid "  --msg2                Print a msg2 message to stdout"
+msgstr ""
+
+#: src/main.sh:816
+msgid "  --no-confirm          Don't ask before installing packages"
+msgstr ""
+
+#: src/main.sh:819
+msgid "  --pass-env            Pass the current user's environment variables"
+msgstr ""
+
+#: src/main.sh:809
+msgid "  --print-control       Print a generated control file and exit"
+msgstr ""
+
+#: src/main.sh:810
+msgid "  --print-srcinfo       Print a generated .SRCINFO file and exit"
+msgstr ""
+
+#: src/main.sh:811
+msgid ""
+"  --skip-pgp-check      Do not verify source files against PGP signatures"
+msgstr ""
+
+#: src/main.sh:824
+msgid "  --warning             Print a warning message to stderr"
+msgstr ""
+
+#: src/main.sh:825
+msgid "  --warning2            Print a warning2 message to stderr"
+msgstr ""
+
+#: src/main.sh:798
+msgid "  -A, --ignore-arch     Ignore errors about mismatching architectures"
+msgstr ""
+
+#: src/main.sh:800
+msgid ""
+"  -F, --file, -p        Specify a location to the build file (defaults to "
+"'PKGBUILD')"
+msgstr ""
+
+#: src/main.sh:803
+msgid ""
+"  -H, --field           Append the packaged control file with custom control "
+"fields"
+msgstr ""
+
+#: src/main.sh:805
+msgid "  -V, --version         Show version information and exit"
+msgstr ""
+
+#: src/main.sh:799
+msgid "  -d, --no-deps         Skip all dependency checks"
+msgstr ""
+
+#: src/main.sh:801
+msgid "  -g, --gen-integ       Generate hashes for source files"
+msgstr ""
+
+#: src/main.sh:802
+msgid "  -h, --help            Show this help menu and exit"
+msgstr ""
+
+#: src/main.sh:804
+msgid ""
+"  -i, --install         Automatically install the built package(s) after "
+"building"
+msgstr ""
+
+#: src/main.sh:806
+msgid ""
+"  -r, --rm-deps         Run 'apt-get autoremove' after a succesfull build"
+msgstr ""
+
+#: src/main.sh:807
+msgid "  -s, --sync-deps       Install missing dependencies"
+msgstr ""
+
+#: src/functions/lint_pkgbuild/options.sh:52
+msgid "%s array contains unknown option '%s'"
+msgstr ""
+
+#: src/functions/lint_pkgbuild/arch_specific.sh:53
+#: src/functions/lint_pkgbuild/arch_specific.sh:74
+msgid "%s can not be architecture specific: %s"
+msgstr ""
+
+#: src/functions/lint_pkgbuild/package_function_variable.sh:46
+#: src/functions/lint_pkgbuild/package_function_variable.sh:55
+msgid "%s can not be set inside a package function"
+msgstr ""
+
+#: src/main.sh:1052
+msgid "%s contains %s characters and cannot be sourced."
+msgstr ""
+
+#: src/functions/lint_pkgbuild/pkgname.sh:60
+msgid "%s contains an invalid prefix: '%s'"
+msgstr ""
+
+#: src/functions/lint_pkgbuild/pkgver.sh:43
+msgid "%s contains invalid characters."
+msgstr ""
+
+#: src/functions/lint_config/source_date_epoch.sh:33
+msgid "%s contains invalid characters: %s"
+msgstr ""
+
+#: src/functions/lint_config/paths.sh:39 src/functions/lint_pkgbuild/arch.sh:47
+#: src/functions/lint_pkgbuild/pkgname.sh:73
+msgid "%s contains invalid characters: '%s'"
+msgstr ""
+
+#: src/functions/lint_config/ext.sh:38
+msgid "%s does not contain a valid package suffix (needs '%s', got '%s')"
+msgstr ""
+
+#: src/main.sh:1047
+msgid "%s does not exist."
+msgstr ""
+
+#: src/functions/lint_package/missing_backup.sh:35
+msgid "%s entry file not in package : %s"
+msgstr ""
+
+#: src/functions/lint_pkgbuild/backup.sh:45
+msgid "%s entry should start with a foward slash : %s"
+msgstr ""
+
+#: src/functions/lint_pkgbuild/util.sh:34
+msgid "%s file (%s) does not exist or is not a regular file."
+msgstr ""
+
+#: src/functions/source/fossil.sh:88 src/functions/source/fossil.sh:94
+msgid "%s is not a checkout of %s repo %s"
+msgstr ""
+
+#: src/functions/source/git.sh:85 src/functions/source/fossil.sh:58
+msgid "%s is not a clone of %s"
+msgstr ""
+
+#: src/functions/lint_pkgbuild/pkgver.sh:36
+#: src/functions/lint_pkgbuild/pkgname.sh:38
+#: src/functions/lint_pkgbuild/pkgname.sh:85
+#: src/functions/lint_pkgbuild/pkgrel.sh:35
+msgid "%s is not allowed to be empty."
+msgstr ""
+
+#: src/functions/lint_pkgbuild/pkgname.sh:48
+msgid "%s is not allowed to start with a dot."
+msgstr ""
+
+#: src/functions/lint_pkgbuild/pkgname.sh:43
+msgid "%s is not allowed to start with a hyphen."
+msgstr ""
+
+#: src/functions/lint_pkgbuild/arch.sh:59
+#: src/functions/lint_pkgbuild/arch.sh:68
+msgid "%s is not available for the '%s' architecture."
+msgstr ""
+
+#: src/main.sh:232
 msgid "%s is not writeable -- pkgver will not be updated"
 msgstr ""
 
-#: src/main.sh:237
-msgid "Unable to find source file %s."
+#: src/functions/lint_pkgbuild/pkgname.sh:53
+msgid "%s may only contain ascii characters."
 msgstr ""
 
-#: src/main.sh:238 src/main.sh:246 src/main.sh:491 src/main.sh:951
-#: src/main.sh:956 src/main.sh:961 src/main.sh:967 src/main.sh:977
+#: src/functions/lint_pkgbuild/epoch.sh:36
+msgid "%s must be an integer, not %s."
+msgstr ""
+
+#: src/main.sh:1057
+msgid "%s must be in the current working directory."
+msgstr ""
+
+#: src/functions/util/config.sh:41
+msgid "%s not found."
+msgstr ""
+
+#: src/functions/lint_config/variable.sh:47
+#: src/functions/lint_pkgbuild/variable.sh:40
+#: src/functions/lint_pkgbuild/variable.sh:52
+#: src/functions/lint_pkgbuild/variable.sh:72
+#: src/functions/lint_pkgbuild/variable.sh:82
+msgid "%s should be an array"
+msgstr ""
+
+#: src/functions/lint_config/variable.sh:57
+#: src/functions/lint_pkgbuild/variable.sh:62
+#: src/functions/lint_pkgbuild/variable.sh:90
+msgid "%s should not be an array"
+msgstr ""
+
+#: src/main.sh:939
+msgid "%s signal caught. Exiting..."
+msgstr ""
+
+#: src/functions/source/local.sh:39
+msgid "%s was not found in the build directory and is not a URL."
+msgstr ""
+
+#: src/functions/util/compress.sh:38
+msgid "'%s' is not a valid archive extension."
+msgstr ""
+
+#: src/main.sh:248
+msgid "A failure occurred in %s()."
+msgstr ""
+
+#: src/functions/lint_pkgbuild/maintainer.sh:7
+msgid ""
+"A maintainer must be specified. This will be an error in a future release."
+msgstr ""
+
+#: src/main.sh:691
+msgid "A package has already been built, installing existing package..."
+msgstr ""
+
+#: src/main.sh:695
+msgid "A package has already been built. (use %s to overwrite)"
+msgstr ""
+
+#: src/main.sh:1235
+msgid "A source package has already been built. (use %s to overwrite)"
+msgstr ""
+
+#: src/main.sh:241 src/main.sh:249 src/main.sh:475 src/main.sh:977
+#: src/main.sh:982 src/main.sh:987 src/main.sh:993 src/main.sh:1003
 #: src/functions/executable/vcs.sh:46 src/functions/source/file.sh:75
 #: src/functions/source/file.sh:145 src/functions/source/svn.sh:63
 #: src/functions/source/svn.sh:73 src/functions/source/hg.sh:52
@@ -69,292 +291,46 @@ msgstr ""
 msgid "Aborting..."
 msgstr ""
 
-#: src/main.sh:245
-msgid "A failure occurred in %s()."
-msgstr ""
-
-#: src/main.sh:361
-msgid "Invalid value for %s: %s"
-msgstr ""
-
-#: src/main.sh:490
-msgid "Missing %s directory."
-msgstr ""
-
-#: src/main.sh:496
-msgid "Creating package \"%s\"..."
-msgstr ""
-
-#: src/main.sh:500
-msgid "Setting up package metadata..."
-msgstr ""
-
-#: src/main.sh:504 src/main.sh:598
-msgid "Generating %s file..."
-msgstr ""
-
-#: src/main.sh:513
-msgid "Adding %s file to package..."
-msgstr ""
-
-#: src/main.sh:516
-msgid "Failed to add %s file to package."
-msgstr ""
-
-#: src/main.sh:531
-msgid "Built package %s exists. Removing..."
-msgstr ""
-
-#: src/main.sh:540
-msgid "Compressing package..."
-msgstr ""
-
-#: src/main.sh:591
-msgid "Creating source package..."
-msgstr ""
-
-#: src/main.sh:595 src/main.sh:608
-msgid "Adding %s..."
-msgstr ""
-
-#: src/main.sh:629
+#: src/main.sh:623
 msgid "Adding %s file (%s)..."
 msgstr ""
 
-#: src/main.sh:640
-msgid "Compressing source package..."
+#: src/main.sh:501
+msgid "Adding %s file to package..."
 msgstr ""
 
-#: src/main.sh:650
-msgid "Failed to create source package file."
+#: src/main.sh:589 src/main.sh:602
+msgid "Adding %s..."
 msgstr ""
 
-#: src/main.sh:665
-msgid "Installing package %s..."
+#: src/functions/lint_pkgbuild/arch.sh:78
+msgid "Architecture '%s' cannot contain PKGBUILD variable reference '%s'."
 msgstr ""
 
-#: src/main.sh:667
-msgid "Installing %s package group..."
+#: src/functions/source/bzr.sh:52
+msgid "Branching %s..."
 msgstr ""
 
-#: src/main.sh:679
-msgid "Failed to install built package(s)."
+#: src/main.sh:525
+msgid "Built package %s exists. Removing..."
 msgstr ""
 
-#: src/main.sh:684
-msgid "Marking built package(s) as automatically installed..."
-msgstr ""
-
-#: src/main.sh:687
-msgid "Failed to mark built package(s) as automatically installed."
-msgstr ""
-
-#: src/main.sh:700
-msgid "A package has already been built, installing existing package..."
-msgstr ""
-
-#: src/main.sh:704
-msgid "A package has already been built. (use %s to overwrite)"
-msgstr ""
-
-#: src/main.sh:723
+#: src/functions/lint_pkgbuild/arch_specific.sh:43
+#: src/functions/lint_pkgbuild/arch_specific.sh:65
 msgid ""
-"The package group has already been built, installing existing packages..."
+"Can not provide architecture specific variables for the '%s' architecture: %s"
 msgstr ""
 
-#: src/main.sh:727
-msgid "The package group has already been built. (use %s to overwrite)"
-msgstr ""
-
-#: src/main.sh:732
-msgid "Part of the package group has already been built. (use %s to overwrite)"
-msgstr ""
-
-#: src/main.sh:802
-msgid "makedeb takes PKGBUILD files and creates archives installable via APT"
-msgstr ""
-
-#: src/main.sh:804
-msgid "Usage: %s [options]"
-msgstr ""
-
-#: src/main.sh:806
-msgid "Options:"
-msgstr ""
-
-#: src/main.sh:807
-msgid "  -A, --ignore-arch    Ignore errors about mismatching architectures"
-msgstr ""
-
-#: src/main.sh:808
-msgid "  -d, --no-deps        Skip all dependency checks"
-msgstr ""
-
-#: src/main.sh:809
-msgid ""
-"  -F, --file, -p       Specify a location to the build file (defaults to "
-"'PKGBUILD')"
-msgstr ""
-
-#: src/main.sh:810
-msgid "  -g, --gen-integ      Generate hashes for source files"
-msgstr ""
-
-#: src/main.sh:811
-msgid "  -h, --help           Show this help menu and exit"
-msgstr ""
-
-#: src/main.sh:812
-msgid ""
-"  -H, --field          Append the packaged control file with custom control "
-"fields"
-msgstr ""
-
-#: src/main.sh:813
-msgid ""
-"  -i, --install        Automatically install the built package(s) after "
-"building"
-msgstr ""
-
-#: src/main.sh:814
-msgid "  -V, --version        Show version information and exit"
-msgstr ""
-
-#: src/main.sh:815
-msgid ""
-"  -r, --rm-deps        Remove installed makedepends and checkdepends after "
-"building"
-msgstr ""
-
-#: src/main.sh:816
-msgid "  -s, --sync-deps      Install missing dependencies"
-msgstr ""
-
-#: src/main.sh:817
-msgid "  --lint               Link the PKGBUILD for conformity requirements"
-msgstr ""
-
-#: src/main.sh:818
-msgid "  --print-control      Print a generated control file and exit"
-msgstr ""
-
-#: src/main.sh:819
-msgid "  --print-srcinfo      Print a generated .SRCINFO file and exit"
-msgstr ""
-
-#: src/main.sh:820
-msgid ""
-"  --skip-pgp-check     Do not verify source files against PGP signatures"
-msgstr ""
-
-#: src/main.sh:822
-msgid ""
-"The following options can modify the behavior of APT during package and "
-"dependency installation:"
-msgstr ""
-
-#: src/main.sh:823
-msgid "  --as-deps            Mark built packages as automatically installed"
-msgstr ""
-
-#: src/main.sh:824
-msgid "  --no-confirm         Don't ask before installing packages"
-msgstr ""
-
-#: src/main.sh:826
-msgid ""
-"See makedeb(8) for information on available options and links for obtaining "
-"support."
-msgstr ""
-
-#: src/main.sh:919
-msgid "%s signal caught. Exiting..."
-msgstr ""
-
-#: src/main.sh:983
-msgid ""
-"Running %s as root is not allowed as it can cause permanent,\\ncatastrophic "
-"damage to your system."
-msgstr ""
-
-#: src/main.sh:988
-msgid "Do not use the %s option. This option is only for internal use by %s."
-msgstr ""
-
-#: src/main.sh:1019
-msgid "%s does not exist."
-msgstr ""
-
-#: src/main.sh:1024
-msgid "%s contains %s characters and cannot be sourced."
-msgstr ""
-
-#: src/main.sh:1029
-msgid "%s must be in the current working directory."
-msgstr ""
-
-#: src/main.sh:1126
-msgid "The key %s does not exist in your keyring."
-msgstr ""
-
-#: src/main.sh:1128
-msgid "There is no key in your keyring."
-msgstr ""
-
-#: src/main.sh:1170 src/main.sh:1185
-msgid "Leaving %s environment."
-msgstr ""
-
-#: src/main.sh:1189
-msgid "Making package: %s"
-msgstr ""
-
-#: src/main.sh:1195
-msgid "A source package has already been built. (use %s to overwrite)"
-msgstr ""
-
-#: src/main.sh:1215
-msgid "Signing package..."
-msgstr ""
-
-#: src/main.sh:1219
-msgid "Source package created: %s"
-msgstr ""
-
-#: src/main.sh:1226
-msgid "Skipping dependency checks."
-msgstr ""
-
-#: src/main.sh:1229
-msgid "Checking for missing dependencies..."
-msgstr ""
-
-#: src/main.sh:1246
-msgid "Using existing %s tree"
-msgstr ""
-
-#: src/main.sh:1253 src/main.sh:1281
-msgid "Removing existing %s directory..."
-msgstr ""
-
-#: src/main.sh:1276
-msgid "Sources are ready."
-msgstr ""
-
-#: src/main.sh:1303
-msgid "Package directory is ready."
-msgstr ""
-
-#: src/main.sh:1307
-msgid "Finished making: %s"
-msgstr ""
-
-#: src/functions/executable/gzip.sh:34
-msgid "Cannot find the %s binary required for compressing man and info pages."
+#: src/functions/lint_pkgbuild/arch.sh:40
+msgid "Can not use '%s' architecture with other architectures"
 msgstr ""
 
 #: src/functions/executable/ccache.sh:34
 msgid "Cannot find the %s binary required for compiler cache usage."
+msgstr ""
+
+#: src/functions/executable/gzip.sh:34
+msgid "Cannot find the %s binary required for compressing man and info pages."
 msgstr ""
 
 #: src/functions/executable/distcc.sh:34
@@ -369,249 +345,237 @@ msgstr ""
 msgid "Cannot find the %s binary required for signing packages."
 msgstr ""
 
-#: src/functions/executable/gpg.sh:43
-msgid "Cannot find the %s binary required for verifying source files."
-msgstr ""
-
-#: src/functions/executable/sudo.sh:33
-msgid "Cannot find the %s binary. Will use %s to acquire root privileges."
-msgstr ""
-
 #: src/functions/executable/checksum.sh:38
 msgid ""
 "Cannot find the %s binary required for source file checksums operations."
+msgstr ""
+
+#: src/functions/executable/gpg.sh:43
+msgid "Cannot find the %s binary required for verifying source files."
 msgstr ""
 
 #: src/functions/executable/fakeroot.sh:33
 msgid "Cannot find the %s binary."
 msgstr ""
 
-#: src/functions/executable/vcs.sh:45 src/functions/util/source.sh:161
-msgid "Unknown download protocol: %s"
+#: src/functions/executable/sudo.sh:33
+msgid "Cannot find the %s binary. Will use %s to acquire root privileges."
 msgstr ""
 
 #: src/functions/executable/vcs.sh:85
 msgid "Cannot find the %s package needed to handle %s sources."
 msgstr ""
 
-#: src/functions/lint_config/source_date_epoch.sh:33
-msgid "%s contains invalid characters: %s"
+#: src/main.sh:1269
+msgid "Checking for missing dependencies..."
 msgstr ""
 
-#: src/functions/lint_config/variable.sh:47
-#: src/functions/lint_pkgbuild/variable.sh:40
-#: src/functions/lint_pkgbuild/variable.sh:52
-#: src/functions/lint_pkgbuild/variable.sh:72
-#: src/functions/lint_pkgbuild/variable.sh:82
-msgid "%s should be an array"
+#: src/functions/lint_package.sh:41
+msgid "Checking for packaging issues..."
 msgstr ""
 
-#: src/functions/lint_config/variable.sh:57
-#: src/functions/lint_pkgbuild/variable.sh:62
-#: src/functions/lint_pkgbuild/variable.sh:90
-msgid "%s should not be an array"
+#. If it's a clean exit and -c/--clean has been passed...
+#: src/main.sh:163
+msgid "Cleaning up..."
 msgstr ""
 
-#: src/functions/lint_config/ext.sh:38
-msgid "%s does not contain a valid package suffix (needs '%s', got '%s')"
+#: src/functions/source/svn.sh:69 src/functions/source/hg.sh:49
+#: src/functions/source/git.sh:67 src/functions/source/fossil.sh:49
+msgid "Cloning %s %s repo..."
 msgstr ""
 
-#: src/functions/lint_config/paths.sh:39 src/functions/lint_pkgbuild/arch.sh:47
-#: src/functions/lint_pkgbuild/pkgname.sh:78
-msgid "%s contains invalid characters: '%s'"
-msgstr ""
-
-#: src/functions/source.sh:40
-msgid "Retrieving sources..."
-msgstr ""
-
-#: src/functions/source.sh:73
-msgid "Extracting sources..."
-msgstr ""
-
-#: src/functions/tidy/strip.sh:119
-msgid "Stripping unneeded symbols from binaries and libraries..."
-msgstr ""
-
-#: src/functions/tidy/purge.sh:35
-msgid "Purging unwanted files..."
-msgstr ""
-
-#: src/functions/tidy/libtool.sh:35
-msgid "Removing %s files..."
-msgstr ""
-
-#: src/functions/tidy/emptydirs.sh:35
-msgid "Removing empty directories..."
-msgstr ""
-
-#: src/functions/tidy/docs.sh:34
-msgid "Removing doc files..."
-msgstr ""
-
-#: src/functions/tidy/staticlibs.sh:35
-msgid "Removing static library files..."
+#: src/main.sh:797
+msgid "Common options:"
 msgstr ""
 
 #: src/functions/tidy/zipman.sh:35
 msgid "Compressing man and info pages..."
 msgstr ""
 
-#: src/functions/integrity/verify_signature.sh:33
-msgid "Verifying source file signatures with %s..."
+#: src/main.sh:534
+msgid "Compressing package..."
 msgstr ""
 
-#: src/functions/integrity/verify_signature.sh:66
-#: src/functions/integrity/verify_signature.sh:84
-#: src/functions/integrity/verify_signature.sh:87
-#: src/functions/integrity/verify_checksum.sh:75
-msgid "FAILED"
+#. tar it up
+#: src/main.sh:634
+msgid "Compressing source package..."
 msgstr ""
 
-#: src/functions/integrity/verify_signature.sh:69
-msgid "unknown public key"
+#: src/functions/lint_pkgbuild/package_function.sh:38
+msgid "Conflicting %s and %s functions in %s"
 msgstr ""
 
-#: src/functions/integrity/verify_signature.sh:72
-msgid "public key %s has been revoked"
+#: src/functions/lint_pkgbuild/control_fields.sh:30
+msgid "Control field '%s' was found more than once."
 msgstr ""
 
-#: src/functions/integrity/verify_signature.sh:75
-msgid "bad signature from public key"
-msgstr ""
-
-#: src/functions/integrity/verify_signature.sh:78
-msgid "error during signature verification"
-msgstr ""
-
-#: src/functions/integrity/verify_signature.sh:84
-msgid "the public key %s is not trusted"
-msgstr ""
-
-#: src/functions/integrity/verify_signature.sh:87
-msgid "invalid public key"
-msgstr ""
-
-#: src/functions/integrity/verify_signature.sh:90
-#: src/functions/integrity/verify_checksum.sh:73
-msgid "Passed"
-msgstr ""
-
-#: src/functions/integrity/verify_signature.sh:93
-#: src/functions/integrity/verify_signature.sh:97
-msgid "WARNING:"
-msgstr ""
-
-#: src/functions/integrity/verify_signature.sh:93
-msgid "the signature has expired."
-msgstr ""
-
-#: src/functions/integrity/verify_signature.sh:97
-msgid "the key has expired."
-msgstr ""
-
-#: src/functions/integrity/verify_signature.sh:109
-msgid "One or more PGP signatures could not be verified!"
-msgstr ""
-
-#: src/functions/integrity/verify_signature.sh:114
-msgid "Warnings have occurred while verifying the signatures."
-msgstr ""
-
-#: src/functions/integrity/verify_signature.sh:115
-msgid "Please make sure you really trust them."
-msgstr ""
-
-#: src/functions/integrity/verify_signature.sh:131
-#: src/functions/integrity/verify_signature.sh:194
-msgid "SIGNATURE NOT FOUND"
-msgstr ""
-
-#: src/functions/integrity/verify_signature.sh:144
-msgid "SOURCE FILE NOT FOUND"
-msgstr ""
-
-#: src/functions/integrity/generate_checksum.sh:90
-msgid "Generating checksums for source files..."
-msgstr ""
-
-#: src/functions/integrity/generate_checksum.sh:105
-msgid "Invalid integrity algorithm '%s' specified."
-msgstr ""
-
-#: src/functions/integrity/verify_checksum.sh:61
-msgid "Skipped"
-msgstr ""
-
-#: src/functions/integrity/verify_checksum.sh:66
-msgid "NOT FOUND"
-msgstr ""
-
-#: src/functions/integrity/verify_checksum.sh:92
-msgid "Validating %s files with %s..."
-msgstr ""
-
-#: src/functions/integrity/verify_checksum.sh:99
-msgid "One or more files did not pass the validity check!"
+#: src/functions/lint_pkgbuild/source.sh:105
+msgid "Couldn't find enough hashsums for '%s' under '%s'."
 msgstr ""
 
 #: src/functions/integrity/generate_signature.sh:41
 msgid "Created signature file %s."
 msgstr ""
 
-#: src/functions/integrity/generate_signature.sh:43
-msgid "Failed to sign package file %s."
+#: src/main.sh:480
+msgid "Creating package \"%s\"..."
 msgstr ""
 
-#: src/functions/integrity/generate_signature.sh:58
-msgid "Signing package(s)..."
+#: src/main.sh:585
+msgid "Creating source package..."
 msgstr ""
 
-#: src/functions/lint_package/file_names.sh:36
-msgid "Package contains paths with newlines"
+#: src/functions/source/svn.sh:95 src/functions/source/hg.sh:79
+#: src/functions/source/bzr.sh:94 src/functions/source/git.sh:106
+#: src/functions/source/fossil.sh:81
+msgid "Creating working copy of %s %s repo..."
+msgstr ""
+
+#: src/functions/lint_pkgbuild/depends.sh:70
+msgid "Dependency '%s' under '%s' contains an invalid prefix: '%s'"
+msgstr ""
+
+#: src/functions/lint_pkgbuild/depends.sh:64
+msgid "Dependency '%s' under '%s' contains more than one '!'."
+msgstr ""
+
+#: src/functions/lint_pkgbuild/arch.sh:56
+msgid "Detected invalid architecture '%s'. Please use '%s' instead."
+msgstr ""
+
+#: src/main.sh:1014
+msgid "Do not use the %s option. This option is only for internal use by %s."
 msgstr ""
 
 #: src/functions/lint_package/dotfiles.sh:34
 msgid "Dotfile found in package root '%s'"
 msgstr ""
 
-#: src/functions/lint_package/build_references.sh:36
-msgid "Package contains reference to %s"
+#: src/functions/source/file.sh:55
+msgid "Downloading %s..."
 msgstr ""
 
-#: src/functions/lint_package/missing_backup.sh:35
-msgid "%s entry file not in package : %s"
+#: src/main.sh:201
+msgid "Entering %s environment..."
 msgstr ""
 
-#: src/functions/lint_pkgbuild/pkgver.sh:36
-#: src/functions/lint_pkgbuild/pkgname.sh:36
-#: src/functions/lint_pkgbuild/pkgname.sh:90
-#: src/functions/lint_pkgbuild/pkgrel.sh:35
-msgid "%s is not allowed to be empty."
+#: src/functions/lint_pkgbuild/package_function.sh:46
+msgid "Extra %s function for split package '%s'"
 msgstr ""
 
-#: src/functions/lint_pkgbuild/pkgver.sh:43
-msgid "%s contains invalid characters."
+#: src/functions/source/file.sh:136
+msgid "Extracting %s with %s"
 msgstr ""
 
-#: src/functions/lint_pkgbuild/epoch.sh:36
-msgid "%s must be an integer, not %s."
+#: src/functions/source.sh:73
+msgid "Extracting sources..."
 msgstr ""
 
-#: src/functions/lint_pkgbuild/options.sh:52
-msgid "%s array contains unknown option '%s'"
+#: src/functions/integrity/verify_signature.sh:66
+#: src/functions/integrity/verify_signature.sh:84
+#: src/functions/integrity/verify_signature.sh:87
+#: src/functions/integrity/verify_checksum.sh:77
+msgid "FAILED"
 msgstr ""
 
-#: src/functions/lint_pkgbuild/source.sh:45
-msgid "Sparse arrays are not allowed for source"
+#: src/main.sh:504
+msgid "Failed to add %s file to package."
 msgstr ""
 
-#: src/functions/lint_pkgbuild/source.sh:74
-msgid "Sources were listed but no hashes could be found."
+#: src/functions/util/util.sh:114
+msgid "Failed to change to directory %s"
 msgstr ""
 
-#: src/functions/lint_pkgbuild/source.sh:105
-msgid "Couldn't find enough hashsums for '%s' under '%s'."
+#: src/main.sh:1272
+msgid "Failed to check missing dependencies."
+msgstr ""
+
+#: src/main.sh:644
+msgid "Failed to create source package file."
+msgstr ""
+
+#: src/functions/util/util.sh:127
+msgid "Failed to create the directory $%s (%s)."
+msgstr ""
+
+#: src/functions/source/file.sh:144
+msgid "Failed to extract %s"
+msgstr ""
+
+#: src/main.sh:670
+msgid "Failed to install built package(s)."
+msgstr ""
+
+#: src/main.sh:1285
+msgid "Failed to install missing dependencies."
+msgstr ""
+
+#: src/main.sh:678
+msgid "Failed to mark built package(s) as automatically installed."
+msgstr ""
+
+#: src/main.sh:1296
+msgid "Failed to mark installed dependencies as automatically installed."
+msgstr ""
+
+#: src/main.sh:1396
+msgid "Failed to remove dependencies."
+msgstr ""
+
+#: src/functions/integrity/generate_signature.sh:43
+msgid "Failed to sign package file %s."
+msgstr ""
+
+#: src/functions/util/util.sh:143
+msgid "Failed to source %s"
+msgstr ""
+
+#: src/main.sh:224
+msgid "Failed to update %s from %s to %s"
+msgstr ""
+
+#: src/functions/source/bzr.sh:54
+msgid "Failure while branching %s"
+msgstr ""
+
+#: src/functions/source/hg.sh:107 src/functions/source/bzr.sh:105
+#: src/functions/source/git.sh:120 src/functions/source/fossil.sh:99
+#: src/functions/source/fossil.sh:120
+msgid "Failure while creating working copy of %s %s repo"
+msgstr ""
+
+#: src/functions/source/file.sh:74
+msgid "Failure while downloading %s"
+msgstr ""
+
+#: src/functions/source/svn.sh:72 src/functions/source/hg.sh:51
+#: src/functions/source/git.sh:70 src/functions/source/git.sh:76
+#: src/functions/source/fossil.sh:51
+msgid "Failure while downloading %s %s repo"
+msgstr ""
+
+#. only warn on failure to allow offline builds
+#: src/functions/source/bzr.sh:63
+msgid "Failure while pulling %s"
+msgstr ""
+
+#. only warn on failure to allow offline builds
+#: src/functions/source/svn.sh:81 src/functions/source/hg.sh:60
+#: src/functions/source/git.sh:92 src/functions/source/fossil.sh:65
+msgid "Failure while updating %s %s repo"
+msgstr ""
+
+#: src/functions/source/hg.sh:102 src/functions/source/bzr.sh:100
+#: src/functions/source/git.sh:114
+msgid "Failure while updating working copy of %s %s repo"
+msgstr ""
+
+#: src/main.sh:1390
+msgid "Finished making: %s"
+msgstr ""
+
+#: src/functions/source/file.sh:36 src/functions/source/local.sh:36
+msgid "Found %s"
 msgstr ""
 
 #: src/functions/lint_pkgbuild/source.sh:108
@@ -625,25 +589,66 @@ msgstr ""
 msgid "Found unused hash variable '%s'. Maybe add '%s'?"
 msgstr ""
 
-#: src/functions/lint_pkgbuild/pkgdesc.sh:5
-msgid "pkgdesc must be set."
+#: src/main.sh:488 src/main.sh:592
+msgid "Generating %s file..."
 msgstr ""
 
-#: src/functions/lint_pkgbuild/pkgdesc.sh:10
-msgid "pkgdesc cannot be empty."
+#: src/functions/integrity/generate_checksum.sh:90
+msgid "Generating checksums for source files..."
 msgstr ""
 
-#: src/functions/lint_pkgbuild/pkgdesc.sh:15
-msgid "pkgdesc must contain characters other than spaces."
+#: src/main.sh:658
+msgid "Installing %s package group..."
 msgstr ""
 
-#: src/functions/lint_pkgbuild/distro_dependencies.sh:13
-msgid "Variable '%s' is not allowed to appear in PKGBUILDs."
+#. Install the missing deps.
+#: src/main.sh:1282
+msgid "Installing missing dependencies..."
 msgstr ""
 
-#: src/functions/lint_pkgbuild/maintainer.sh:7
-msgid ""
-"A maintainer must be specified. This will be an error in a future release."
+#: src/main.sh:656
+msgid "Installing package %s..."
+msgstr ""
+
+#: src/functions/lint_pkgbuild/pkgrel.sh:40
+msgid "Invalid characters in %s."
+msgstr ""
+
+#: src/functions/integrity/generate_checksum.sh:105
+msgid "Invalid integrity algorithm '%s' specified."
+msgstr ""
+
+#: src/main.sh:364
+msgid "Invalid value for %s: %s"
+msgstr ""
+
+#: src/main.sh:1210 src/main.sh:1225
+msgid "Leaving %s environment."
+msgstr ""
+
+#: src/main.sh:1229
+msgid "Making package: %s"
+msgstr ""
+
+#: src/main.sh:675
+msgid "Marking built package(s) as automatically installed..."
+msgstr ""
+
+#. Mark newly installed packages as automatically installed.
+#: src/main.sh:1294
+msgid "Marking newly installed packages as automatically installed..."
+msgstr ""
+
+#: src/main.sh:474
+msgid "Missing %s directory."
+msgstr ""
+
+#: src/functions/lint_pkgbuild/package_function.sh:51
+msgid "Missing %s function for split package '%s'"
+msgstr ""
+
+#: src/functions/lint_pkgbuild/package_function.sh:41
+msgid "Missing %s function in %s"
 msgstr ""
 
 #: src/functions/lint_pkgbuild/maintainer.sh:9
@@ -652,134 +657,218 @@ msgid ""
 "release."
 msgstr ""
 
-#: src/functions/lint_pkgbuild/arch.sh:40
-msgid "Can not use '%s' architecture with other architectures"
+#: src/functions/lint_pkgbuild/depends.sh:87
+msgid "More than one version restrictor was specified for %s: %s"
 msgstr ""
 
-#: src/functions/lint_pkgbuild/arch.sh:56
-msgid "Detected invalid architecture '%s'. Please use '%s' instead."
+#: src/functions/integrity/verify_checksum.sh:68
+msgid "NOT FOUND"
 msgstr ""
 
-#: src/functions/lint_pkgbuild/arch.sh:59
-#: src/functions/lint_pkgbuild/arch.sh:68
-msgid "%s is not available for the '%s' architecture."
+#: src/functions/integrity/verify_signature.sh:109
+msgid "One or more PGP signatures could not be verified!"
 msgstr ""
 
-#: src/functions/lint_pkgbuild/arch.sh:78
-msgid "Architecture '%s' cannot contain PKGBUILD variable reference '%s'."
+#: src/functions/integrity/verify_checksum.sh:101
+msgid "One or more files did not pass the validity check!"
 msgstr ""
 
-#: src/functions/lint_pkgbuild/package_function.sh:38
-msgid "Conflicting %s and %s functions in %s"
+#: src/functions/lint_package/file_names.sh:36
+msgid "Package contains paths with newlines"
 msgstr ""
 
-#: src/functions/lint_pkgbuild/package_function.sh:41
-msgid "Missing %s function in %s"
+#: src/functions/lint_package/build_references.sh:36
+msgid "Package contains reference to %s"
 msgstr ""
 
-#: src/functions/lint_pkgbuild/package_function.sh:46
-msgid "Extra %s function for split package '%s'"
+#: src/main.sh:1386
+msgid "Package directory is ready."
 msgstr ""
 
-#: src/functions/lint_pkgbuild/package_function.sh:51
-msgid "Missing %s function for split package '%s'"
+#: src/main.sh:723
+msgid "Part of the package group has already been built. (use %s to overwrite)"
 msgstr ""
 
-#: src/functions/lint_pkgbuild/util.sh:34
-msgid "%s file (%s) does not exist or is not a regular file."
+#: src/functions/integrity/verify_signature.sh:90
+#: src/functions/integrity/verify_checksum.sh:75
+msgid "Passed"
 msgstr ""
 
-#: src/functions/lint_pkgbuild/pkgname.sh:41
-msgid "%s is not allowed to start with a hyphen."
+#: src/functions/integrity/verify_signature.sh:115
+msgid "Please make sure you really trust them."
 msgstr ""
 
-#: src/functions/lint_pkgbuild/pkgname.sh:46
-msgid "%s is not allowed to start with a dot."
+#: src/functions/source/bzr.sh:59
+msgid "Pulling %s..."
 msgstr ""
 
-#: src/functions/lint_pkgbuild/pkgname.sh:51
-msgid "%s may only contain ascii characters."
+#: src/functions/tidy/purge.sh:35
+msgid "Purging unwanted files..."
 msgstr ""
 
-#: src/functions/lint_pkgbuild/pkgname.sh:58
-#: src/functions/lint_pkgbuild/pkgname.sh:65
-msgid "%s contains an invalid prefix: '%s'"
+#: src/functions/tidy/libtool.sh:35
+msgid "Removing %s files..."
 msgstr ""
 
-#: src/functions/lint_pkgbuild/pkgrel.sh:40
-msgid "Invalid characters in %s."
+#: src/functions/tidy/docs.sh:34
+msgid "Removing doc files..."
 msgstr ""
 
-#: src/functions/lint_pkgbuild/provides.sh:46
-msgid "%s array cannot contain comparison (< or >) operators."
+#: src/functions/tidy/emptydirs.sh:35
+msgid "Removing empty directories..."
 msgstr ""
 
-#: src/functions/lint_pkgbuild/package_function_variable.sh:46
-#: src/functions/lint_pkgbuild/package_function_variable.sh:55
-msgid "%s can not be set inside a package function"
+#: src/main.sh:1336 src/main.sh:1364
+msgid "Removing existing %s directory..."
+msgstr ""
+
+#: src/functions/tidy/staticlibs.sh:35
+msgid "Removing static library files..."
+msgstr ""
+
+#: src/main.sh:1394
+msgid "Removing unneeded dependencies..."
 msgstr ""
 
 #: src/functions/lint_pkgbuild/pkglist.sh:38
 msgid "Requested package %s is not provided in %s"
 msgstr ""
 
-#: src/functions/lint_pkgbuild/backup.sh:45
-msgid "%s entry should start with a foward slash : %s"
+#: src/functions/source.sh:40
+msgid "Retrieving sources..."
 msgstr ""
 
-#: src/functions/lint_pkgbuild/control_fields.sh:30
-msgid "Control field '%s' was found more than once."
-msgstr ""
-
-#: src/functions/lint_pkgbuild/arch_specific.sh:43
-#: src/functions/lint_pkgbuild/arch_specific.sh:65
+#: src/main.sh:1009
 msgid ""
-"Can not provide architecture specific variables for the '%s' architecture: %s"
+"Running %s as root is not allowed as it can cause permanent,\\ncatastrophic "
+"damage to your system."
 msgstr ""
 
-#: src/functions/lint_pkgbuild/arch_specific.sh:53
-#: src/functions/lint_pkgbuild/arch_specific.sh:74
-msgid "%s can not be architecture specific: %s"
+#: src/functions/integrity/verify_signature.sh:131
+#: src/functions/integrity/verify_signature.sh:194
+msgid "SIGNATURE NOT FOUND"
 msgstr ""
 
-#: src/functions/tidy.sh:41
-msgid "Tidying install..."
+#: src/functions/integrity/verify_signature.sh:144
+msgid "SOURCE FILE NOT FOUND"
+msgstr ""
+
+#: src/main.sh:829
+msgid ""
+"See makedeb(8) for information on all available options and links for "
+"obtaining support."
+msgstr ""
+
+#: src/main.sh:484
+msgid "Setting up package metadata..."
+msgstr ""
+
+#: src/functions/integrity/generate_signature.sh:58
+msgid "Signing package(s)..."
+msgstr ""
+
+#: src/main.sh:1255
+msgid "Signing package..."
+msgstr ""
+
+#: src/functions/integrity/verify_checksum.sh:63
+msgid "Skipped"
 msgstr ""
 
 #: src/functions/integrity.sh:34
 msgid "Skipping all source file integrity checks."
 msgstr ""
 
-#: src/functions/integrity.sh:36
-msgid "Skipping verification of source file checksums."
+#: src/main.sh:1266
+msgid "Skipping dependency checks."
 msgstr ""
 
 #: src/functions/integrity.sh:39
 msgid "Skipping verification of source file PGP signatures."
 msgstr ""
 
-#: src/functions/source/file.sh:36 src/functions/source/local.sh:36
-msgid "Found %s"
+#: src/functions/integrity.sh:36
+msgid "Skipping verification of source file checksums."
 msgstr ""
 
-#: src/functions/source/file.sh:55
-msgid "Downloading %s..."
+#: src/main.sh:1259
+msgid "Source package created: %s"
 msgstr ""
 
-#: src/functions/source/file.sh:74
-msgid "Failure while downloading %s"
+#: src/main.sh:1359
+msgid "Sources are ready."
 msgstr ""
 
-#: src/functions/source/file.sh:136
-msgid "Extracting %s with %s"
+#: src/functions/lint_pkgbuild/source.sh:74
+msgid "Sources were listed but no hashes could be found."
 msgstr ""
 
-#: src/functions/source/file.sh:144
-msgid "Failed to extract %s"
+#: src/functions/lint_pkgbuild/source.sh:45
+msgid "Sparse arrays are not allowed for source"
 msgstr ""
 
-#: src/functions/source/local.sh:39
-msgid "%s was not found in the build directory and is not a URL."
+#: src/main.sh:208 src/main.sh:307
+msgid "Starting %s()..."
+msgstr ""
+
+#: src/functions/tidy/strip.sh:119
+msgid "Stripping unneeded symbols from binaries and libraries..."
+msgstr ""
+
+#: src/functions/util/source.sh:170
+msgid "The download program %s is not installed."
+msgstr ""
+
+#: src/main.sh:1308
+msgid "The following build dependencies are missing:"
+msgstr ""
+
+#: src/main.sh:821
+msgid "The following can be used to print makedeb-styled messages:"
+msgstr ""
+
+#: src/main.sh:818
+msgid ""
+"The following options can modify the behavior of 'sudo' when it is called:"
+msgstr ""
+
+#: src/main.sh:813
+msgid ""
+"The following options can modify the behavior of APT during package and "
+"dependency installation:"
+msgstr ""
+
+#: src/main.sh:1154
+msgid "The key %s does not exist in your keyring."
+msgstr ""
+
+#: src/main.sh:714
+msgid ""
+"The package group has already been built, installing existing packages..."
+msgstr ""
+
+#: src/main.sh:718
+msgid "The package group has already been built. (use %s to overwrite)"
+msgstr ""
+
+#: src/main.sh:1156
+msgid "There is no key in your keyring."
+msgstr ""
+
+#: src/functions/tidy.sh:41
+msgid "Tidying install..."
+msgstr ""
+
+#: src/main.sh:1314
+msgid "Try running '%s'."
+msgstr ""
+
+#: src/main.sh:240
+msgid "Unable to find source file %s."
+msgstr ""
+
+#: src/functions/executable/vcs.sh:45 src/functions/util/source.sh:161
+msgid "Unknown download protocol: %s"
 msgstr ""
 
 #: src/functions/source/svn.sh:62 src/functions/source/hg.sh:93
@@ -788,15 +877,8 @@ msgstr ""
 msgid "Unrecognized reference: %s"
 msgstr ""
 
-#: src/functions/source/svn.sh:69 src/functions/source/hg.sh:49
-#: src/functions/source/git.sh:67 src/functions/source/fossil.sh:49
-msgid "Cloning %s %s repo..."
-msgstr ""
-
-#: src/functions/source/svn.sh:72 src/functions/source/hg.sh:51
-#: src/functions/source/git.sh:70 src/functions/source/git.sh:76
-#: src/functions/source/fossil.sh:51
-msgid "Failure while downloading %s %s repo"
+#: src/main.sh:230
+msgid "Updated version: %s"
 msgstr ""
 
 #: src/functions/source/svn.sh:77 src/functions/source/hg.sh:56
@@ -804,100 +886,117 @@ msgstr ""
 msgid "Updating %s %s repo..."
 msgstr ""
 
-#: src/functions/source/svn.sh:81 src/functions/source/hg.sh:60
-#: src/functions/source/git.sh:92 src/functions/source/fossil.sh:65
-msgid "Failure while updating %s %s repo"
+#: src/main.sh:795
+msgid "Usage: %s [options]"
 msgstr ""
 
-#: src/functions/source/svn.sh:95 src/functions/source/hg.sh:79
-#: src/functions/source/bzr.sh:94 src/functions/source/git.sh:106
-#: src/functions/source/fossil.sh:81
-msgid "Creating working copy of %s %s repo..."
+#: src/main.sh:1329
+msgid "Using existing %s tree"
 msgstr ""
 
-#: src/functions/source/hg.sh:102 src/functions/source/bzr.sh:100
-#: src/functions/source/git.sh:114
-msgid "Failure while updating working copy of %s %s repo"
+#: src/functions/integrity/verify_checksum.sh:94
+msgid "Validating %s files with %s..."
 msgstr ""
 
-#: src/functions/source/hg.sh:107 src/functions/source/bzr.sh:105
-#: src/functions/source/git.sh:120 src/functions/source/fossil.sh:99
-#: src/functions/source/fossil.sh:120
-msgid "Failure while creating working copy of %s %s repo"
+#: src/functions/lint_pkgbuild/distro_dependencies.sh:13
+msgid "Variable '%s' is not allowed to appear in PKGBUILDs."
 msgstr ""
 
-#: src/functions/source/bzr.sh:52
-msgid "Branching %s..."
+#: src/functions/integrity/verify_signature.sh:33
+msgid "Verifying source file signatures with %s..."
 msgstr ""
 
-#: src/functions/source/bzr.sh:54
-msgid "Failure while branching %s"
+#: src/functions/lint_pkgbuild/depends.sh:99
+msgid "Version restrictor %s in %s isn't allowed on %s."
 msgstr ""
 
-#: src/functions/source/bzr.sh:59
-msgid "Pulling %s..."
+#: src/functions/integrity/verify_signature.sh:93
+#: src/functions/integrity/verify_signature.sh:97
+msgid "WARNING:"
 msgstr ""
 
-#: src/functions/source/bzr.sh:63
-msgid "Failure while pulling %s"
-msgstr ""
-
-#: src/functions/source/git.sh:85 src/functions/source/fossil.sh:58
-msgid "%s is not a clone of %s"
-msgstr ""
-
-#: src/functions/source/fossil.sh:88 src/functions/source/fossil.sh:94
-msgid "%s is not a checkout of %s repo %s"
-msgstr ""
-
-#: src/functions/lint_package.sh:41
-msgid "Checking for packaging issues..."
-msgstr ""
-
-#: src/functions/util/source.sh:170
-msgid "The download program %s is not installed."
-msgstr ""
-
-#: src/functions/util/config.sh:41
-msgid "%s not found."
-msgstr ""
-
-#: src/functions/util/parseopts.sh:81
-msgid "option '%s' is ambiguous; possibilities:"
-msgstr ""
-
-#: src/functions/util/parseopts.sh:112
-msgid "option requires an argument"
-msgstr ""
-
-#: src/functions/util/parseopts.sh:134 src/functions/util/parseopts.sh:187
-msgid "invalid option"
-msgstr ""
-
-#: src/functions/util/parseopts.sh:148
-msgid "option '%s' does not allow an argument"
-msgstr ""
-
-#: src/functions/util/parseopts.sh:166
-msgid "option '%s' requires an argument"
-msgstr ""
-
-#: src/functions/util/util.sh:114
-msgid "Failed to change to directory %s"
-msgstr ""
-
-#: src/functions/util/util.sh:127
-msgid "Failed to create the directory $%s (%s)."
+#: src/functions/integrity/verify_signature.sh:114
+msgid "Warnings have occurred while verifying the signatures."
 msgstr ""
 
 #: src/functions/util/util.sh:130
 msgid "You do not have write permission for the directory $%s (%s)."
 msgstr ""
 
-#: src/functions/util/util.sh:143
-msgid "Failed to source %s"
+#: src/main.sh:1297
+msgid "You may need to run 'apt-mark auto' with the following packages:"
 msgstr ""
 
-#: src/functions/util/compress.sh:38
-msgid "'%s' is not a valid archive extension."
+#: src/functions/integrity/verify_signature.sh:75
+msgid "bad signature from public key"
+msgstr ""
+
+#: src/functions/integrity/verify_signature.sh:78
+msgid "error during signature verification"
+msgstr ""
+
+#. parse failure
+#: src/functions/util/parseopts.sh:134 src/functions/util/parseopts.sh:187
+msgid "invalid option"
+msgstr ""
+
+#: src/functions/integrity/verify_signature.sh:87
+msgid "invalid public key"
+msgstr ""
+
+#: src/main.sh:793
+msgid "makedeb takes PKGBUILD files and creates archives installable via APT"
+msgstr ""
+
+#: src/functions/util/parseopts.sh:148
+msgid "option '%s' does not allow an argument"
+msgstr ""
+
+#. fail, ambiguous match
+#: src/functions/util/parseopts.sh:81
+msgid "option '%s' is ambiguous; possibilities:"
+msgstr ""
+
+#: src/functions/util/parseopts.sh:166
+msgid "option '%s' requires an argument"
+msgstr ""
+
+#: src/functions/util/parseopts.sh:112
+msgid "option requires an argument"
+msgstr ""
+
+#: src/functions/lint_pkgbuild/pkgdesc.sh:10
+msgid "pkgdesc cannot be empty."
+msgstr ""
+
+#: src/functions/lint_pkgbuild/pkgdesc.sh:5
+msgid "pkgdesc must be set."
+msgstr ""
+
+#: src/functions/lint_pkgbuild/pkgdesc.sh:15
+msgid "pkgdesc must contain characters other than spaces."
+msgstr ""
+
+#: src/main.sh:214
+msgid "pkgver() generated an invalid version: %s"
+msgstr ""
+
+#: src/functions/integrity/verify_signature.sh:72
+msgid "public key %s has been revoked"
+msgstr ""
+
+#: src/functions/integrity/verify_signature.sh:97
+msgid "the key has expired."
+msgstr ""
+
+#: src/functions/integrity/verify_signature.sh:84
+msgid "the public key %s is not trusted"
+msgstr ""
+
+#: src/functions/integrity/verify_signature.sh:93
+msgid "the signature has expired."
+msgstr ""
+
+#: src/functions/integrity/verify_signature.sh:69
+msgid "unknown public key"
 msgstr ""

--- a/src/functions/dependencies/convert_relationships.sh
+++ b/src/functions/dependencies/convert_relationships.sh
@@ -2,34 +2,50 @@ convert_relationships() {
     local target_var="${1}"
     local values=("${@:2}")
     local new_values=()
+    local pkg
+    local pkgs
+    local pkg2
+    local pkglist=()
     local matched_rel
     local pkgname
     local pkgver
 
     for pkg in "${values[@]}"; do
-        for rel in '<=' '>=' '=' '>' '<'; do
-            if echo "${pkg}" | grep -q "${rel}"; then
-                pkgname="$(echo "${pkg}" | sed "s|${rel}.*$||")"
-                pkgver="$(echo "${pkg}" | sed "s|^.*${rel}||")"
+        pkglist=()
+
+        mapfile -t pkgs < <(split_dep_by_pipe "${pkg}")
+
+        for pkg2 in "${pkgs[@]}"; do
+            for rel in '<=' '>=' '=' '>' '<'; do
+                if echo "${pkg2}" | grep -q "${rel}"; then
+                    pkgname="$(echo "${pkg2}" | sed "s|${rel}.*$||")"
+                    pkgver="$(echo "${pkg2}" | sed "s|^.*${rel}||")"
                 
-                # Debian control files use '<<' and '>>' for those respective operators.
-                if [[ "${rel}" == "<" || "${rel}" == ">" ]]; then
-                    matched_rel="${rel}${rel}"
-                else
-                    matched_rel="${rel}"
+                    # Debian control files use '<<' and '>>' for those respective operators.
+                    if [[ "${rel}" == "<" || "${rel}" == ">" ]]; then
+                        matched_rel="${rel}${rel}"
+                    else
+                        matched_rel="${rel}"
+                    fi
+                
+                    break
                 fi
-                
-                break
+            done
+
+            if [[ "${matched_rel:+x}" == "x" ]]; then
+                pkglist+=("${pkgname} (${matched_rel} ${pkgver})")
+            else
+                pkglist+=("${pkg2}")
             fi
+
+            unset matched_rel
         done
 
-        if [[ "${matched_rel:+x}" == "x" ]]; then
-            new_values+=("${pkgname} (${matched_rel} ${pkgver})")
+        if [[ "${#pkglist[@]}" == 1 ]]; then
+            new_values+=("${pkglist[@]}")
         else
-            new_values+=("${pkg}")
+            new_values+="$(printf '%s\n' "${pkglist[@]}" | sed 's/.*/& | /' | tac | rev | sed '1s/ | //' | rev | tac | tr -d '\n')"
         fi
-
-        unset matched_rel
     done
     
     create_array "${target_var}" "${new_values[@]}"

--- a/src/functions/dependencies/missing_apt_dependencies.py
+++ b/src/functions/dependencies/missing_apt_dependencies.py
@@ -12,69 +12,86 @@ relation_operators = {"<<": lt, "<=": le, "=": eq, ">=": ge, ">>": gt}
 apt_pkg.init()
 cache = apt_pkg.Cache(None)
 
-missing_packages = []
+# bad_dep keeps track of if any dependency in sys.argv is unable
+# to be satisfied. good_dep (seen later in this script) checks
+# each item in a dependency (i.e. 'pkg1' and 'pkg2' in 'pkg1 | pkg2').
+bad_dep = True
 
 for i in sys.argv[1:]:
-    # Build the package relationship string for use by 'apt-get satisfy'.
-    relationship_operator = None
+    # We only pass in one group of dependencies ('pkg1=1 | pkg2>=2') at a time,
+    # so we can safely only get the first item in the returned list.
+    # See https://apt-team.pages.debian.net/python-apt/library/apt_pkg.html#apt_pkg.parse_depends
+    # for how this is layed out.
+    deps = apt_pkg.parse_depends(i)[0]
+    
+    # See if one of the provided deps were found.
+    good_dep = False
 
-    for j in ["<=", ">=", "<", ">", "="]:
-        if j in i:
-            relationship_operator = j
+    for dep in deps:
+        pkgname, pkgver_restrictor, comparator_restrictor = dep
+
+        if comparator_restrictor:
+            ver_comparator = relation_operators[comparator_restrictor]
+
+        try:
+            pkg = cache[pkgname]
+        except KeyError:
+            continue
+
+        # Check if the package in the cache provided this one.
+        if pkg.current_state == apt_pkg.CURSTATE_INSTALLED:
+
+            # If there was no version restrictor, it satisfied the dependency.
+            if pkgver_restrictor == "":
+                good_dep = True
+                break
+
+            # Otherwise, compare the versions see if it passes.
+            ver_result = version_compare(pkg.current_ver.ver_str, pkgver_restrictor)
+
+            if ver_comparator(ver_result, 0):
+                good_dep = True
+                break
+
+        # If not, check if any provided packages do.
+        for provided_pkg in pkg.provides_list:
+            provided_pkgver_restrictor, provided_pkgver_object = provided_pkg[1:]
+            provided_pkg_object = provided_pkgver_object.parent_pkg
+
+            # If this provided package's version isn't installed in the first place, it can't satisfy the dep.
+            if provided_pkg_object.current_state != apt_pkg.CURSTATE_INSTALLED:
+                continue
+
+            # If this dep specified a version restrictor, but this provided package didn't,
+            # it also can't satisfy this dependency.
+            if pkgver_restrictor != "" and provided_pkgver_restrictor is None:
+                continue
+
+            # If no restrictor was specified on both ends, it'll satisfy the dep.
+            if ("", None) == (pkgver_restrictor, provided_pkgver_restrictor):
+                good_dep = True
+                break
+
+            print(repr((pkgver_restrictor, provided_pkgver_restrictor)))
+
+            # Else if the provided package's version satisfies the requirements of the version
+            # restrictor, it'll satisfy the dep.
+            ver_result = version_compare(provided_pkg_object.current_ver.ver_str, pkgver_restrictor)
+
+            if ver_comparator(ver_result, 0):
+                good_dep = True
+                break
+
+        # If good_dep was reached in the loop, break again.
+        if good_dep is True:
             break
 
-    if relationship_operator is not None:
-        if relationship_operator in ["<", ">"]:
-            relationship_operator_formatted = j + j
-        else:
-            relationship_operator_formatted = j
+    # If good_dep was reached, mark bad_dep as false.
+    if good_dep is True:
+        bad_dep = False
 
-        package = i.split(relationship_operator)
-        pkgname = package[0]
-        pkgver = package[1]
-        package_string = f"{pkgname} ({relationship_operator_formatted} {pkgver})"
-    else:
-        pkgname = i
-        pkgver = None
-        package_string = pkgname
-
-    # Check if the package is in the cache.
-    try:
-        pkg = cache[pkgname]
-    except KeyError:
-        missing_packages += [package_string]
-        continue
-
-    # Get the list of installed and provided packages that are currently installed.
-    installed_pkg_versions = []
-
-    if pkg.current_state == CURSTATE_INSTALLED:
-        installed_pkg_versions += [pkg]
-
-    for i in pkg.provides_list:
-        parent_pkg = i[2].parent_pkg
-
-        if parent_pkg.current_state == CURSTATE_INSTALLED:
-            installed_pkg_versions += [parent_pkg]
-
-    # If an installed package was found and no relationship operators were used, the dependency has been satisfied.
-    if (len(installed_pkg_versions) != 0) and (relationship_operator is None):
-        continue
-
-    # Otherwise, check all matching installed packages and see if any of them fit the specified relationship operator.
-    matched_pkg = False
-
-    for i in installed_pkg_versions:
-        installed_version = i.current_ver.ver_str
-        version_result = version_compare(installed_version, pkgver)
-
-        if relation_operators[relationship_operator_formatted](version_result, 0):
-            matched_pkg = True
-
-    if not matched_pkg:
-        missing_packages += [package_string]
-
-for i in missing_packages:
-    print(i)
-
-exit(0)
+# If a 'bad_dep' was found, exit with 1. Otherwise, all deps could be satisfied.
+if bad_dep is True:
+    exit(1)
+else:
+    exit(0)

--- a/src/functions/dependencies/missing_apt_dependencies.py
+++ b/src/functions/dependencies/missing_apt_dependencies.py
@@ -6,7 +6,7 @@ from apt_pkg import CURSTATE_INSTALLED, version_compare
 from operator import lt, le, eq, ge, gt
 
 # Function mappings for relationship operators.
-relation_operators = {"<<": lt, "<=": le, "=": eq, ">=": ge, ">>": gt}
+relation_operators = {"<": lt, "<=": le, "=": eq, ">=": ge, ">": gt}
 
 # Set up APT cache.
 apt_pkg.init()
@@ -15,7 +15,7 @@ cache = apt_pkg.Cache(None)
 # bad_dep keeps track of if any dependency in sys.argv is unable
 # to be satisfied. good_dep (seen later in this script) checks
 # each item in a dependency (i.e. 'pkg1' and 'pkg2' in 'pkg1 | pkg2').
-bad_dep = True
+missing_deps = []
 
 for i in sys.argv[1:]:
     # We only pass in one group of dependencies ('pkg1=1 | pkg2>=2') at a time,
@@ -87,11 +87,9 @@ for i in sys.argv[1:]:
             break
 
     # If good_dep was reached, mark bad_dep as false.
-    if good_dep is True:
-        bad_dep = False
+    if good_dep is not True:
+        missing_deps += [i]
 
-# If a 'bad_dep' was found, exit with 1. Otherwise, all deps could be satisfied.
-if bad_dep is True:
-    exit(1)
-else:
-    exit(0)
+# Show all missing deps.
+for dep in missing_deps:
+    print(dep)

--- a/src/functions/lint_pkgbuild/checkdepends.sh
+++ b/src/functions/lint_pkgbuild/checkdepends.sh
@@ -33,24 +33,5 @@ lint_pkgbuild_functions+=('lint_checkdepends')
 
 
 lint_checkdepends() {
-	local checkdepends_list checkdepend name ver ret=0
-
-	get_pkgbuild_all_split_attributes checkdepends checkdepends_list
-
-	# this function requires extglob - save current status to restore later
-	local shellopts=$(shopt -p extglob)
-	shopt -s extglob
-
-	for checkdepend in "${checkdepends_list[@]}"; do
-		name=${checkdepend%%@(<|>|=|>=|<=)*}
-		lint_one_pkgname checkdepends "$name" || ret=1
-		if [[ $name != "$checkdepend" ]]; then
-			ver=${checkdepend##$name@(<|>|=|>=|<=)}
-			check_fullpkgver "$ver" checkdepends || ret=1
-		fi
-	done
-
-	eval "$shellopts"
-
-	return $ret
+	lint_deps 'checkdepends' '' || return 1
 }

--- a/src/functions/lint_pkgbuild/conflicts.sh
+++ b/src/functions/lint_pkgbuild/conflicts.sh
@@ -33,24 +33,5 @@ lint_pkgbuild_functions+=('lint_conflicts')
 
 
 lint_conflicts() {
-	local conflicts_list conflict name ver ret=0
-
-	get_pkgbuild_all_split_attributes conflicts conflicts_list
-
-	# this function requires extglob - save current status to restore later
-	local shellopts=$(shopt -p extglob)
-	shopt -s extglob
-
-	for conflict in "${conflicts_list[@]}"; do
-		name=${conflict%%@(<|>|=|>=|<=)*}
-		lint_one_pkgname conflicts "$name" || ret=1
-		if [[ $name != "$conflict" ]]; then
-			ver=${conflict##$name@(<|>|=|>=|<=)}
-			check_fullpkgver "$ver" conflicts || ret=1
-		fi
-	done
-
-	eval "$shellopts"
-
-	return $ret
+	lint_deps 'conflicts' '' || return 1
 }

--- a/src/functions/lint_pkgbuild/depends.sh
+++ b/src/functions/lint_pkgbuild/depends.sh
@@ -66,11 +66,14 @@ lint_deps() {
 
 				if [[ "${prefix}" != "" ]] && ! in_array "${prefix}" "${valid_prefixes[@]}"; then
 					error "$(gettext "Dependency '%s' under '%s' contains an invalid prefix: '%s'")" "${k}" "${i}" "${prefix}"
+					ret=1
 				fi
 
-				lint_one_pkgname "${name}"
+				lint_one_pkgname "${name}" || ret=1
 				
-				[[ "${ver}"  != "" ]] && check_pkgver "${ver}"
+				if [[ "${ver}"  != "" ]]; then
+					check_pkgver "${ver}" || ret=1
+				fi
 			done
 		done
 	done

--- a/src/functions/lint_pkgbuild/depends.sh
+++ b/src/functions/lint_pkgbuild/depends.sh
@@ -75,6 +75,10 @@ lint_deps() {
 			mapfile -t deps < <(split_dep_by_pipe "${j}")
 
 			for k in "${deps[@]}"; do
+				if [[ "${var}" == "optdepends" ]]; then
+					k="$(echo "${k}" | sed 's|: .*||')"
+				fi
+
 				name="$(echo "${k}" | grep -o '^[^<>=]*')"
 				mapfile -t restrictor < <(echo "${k}" | grep -Eo '<=|>=|=|<|>')
 				ver="$(echo "${k}" | grep -o '[<>=].*$' | sed -E 's/<=|>=|=|<|>//')"
@@ -88,7 +92,7 @@ lint_deps() {
 				lint_one_pkgname "${name}" "${j}" || ret=1
 				
 				if [[ "${ver}"  != "" ]]; then
-					check_pkgver "${ver}" || ret=1
+					check_pkgver "${ver}" "${k}" || ret=1
 				fi
 
 				if [[ "${var}" == "provides" ]] && [[ "${restrictor+x}" == "x" ]] && [[ "${restrictor}" != "=" ]]; then

--- a/src/functions/lint_pkgbuild/makedepends.sh
+++ b/src/functions/lint_pkgbuild/makedepends.sh
@@ -33,24 +33,5 @@ lint_pkgbuild_functions+=('lint_makedepends')
 
 
 lint_makedepends() {
-	local makedepends_list makedepend name ver ret=0
-
-	get_pkgbuild_all_split_attributes makedepends makedepends_list
-
-	# this function requires extglob - save current status to restore later
-	local shellopts=$(shopt -p extglob)
-	shopt -s extglob
-
-	for makedepend in "${makedepends_list[@]}"; do
-		name=${makedepend%%@(<|>|=|>=|<=)*}
-		lint_one_pkgname makedepends "$name" || ret=1
-		if [[ $name != "$makedepend" ]]; then
-			ver=${makedepend##$name@(<|>|=|>=|<=)}
-			check_fullpkgver "$ver" makedepends || ret=1
-		fi
-	done
-
-	eval "$shellopts"
-
-	return $ret
+	lint_deps 'makedepends' '' || return 1
 }

--- a/src/functions/lint_pkgbuild/optdepends.sh
+++ b/src/functions/lint_pkgbuild/optdepends.sh
@@ -33,22 +33,5 @@ lint_pkgbuild_functions+=('lint_optdepends')
 
 
 lint_optdepends() {
-	local optdepends_list optdepend name ver ret=0
-
-	get_pkgbuild_all_split_attributes optdepends optdepends_list
-
-	# this function requires extglob - save current status to restore later
-	local shellopts=$(shopt -p extglob)
-	shopt -s extglob
-
-	for optdepend in "${optdepends_list[@]%%:[[:space:]]*}"; do
-		name=${optdepend%%@(<|>|=|>=|<=)*}
-		lint_one_pkgname optdepends "$name" || ret=1
-		if [[ $name != "$optdepend" ]]; then
-			ver=${optdepend##$name@(<|>|=|>=|<=)}
-			check_fullpkgver "$ver" optdepends || ret=1
-		fi
-	done
-
-	return $ret
+	lint_deps 'optdepends' 'r s' || return 1
 }

--- a/src/functions/lint_pkgbuild/pkgbase.sh
+++ b/src/functions/lint_pkgbuild/pkgbase.sh
@@ -35,5 +35,5 @@ lint_pkgbase() {
 		return 0
 	fi
 
-	lint_one_pkgname "pkgbase" "$pkgbase"
+	lint_one_pkgname "$pkgbase" 'pkgbase'
 }

--- a/src/functions/lint_pkgbuild/pkgname.sh
+++ b/src/functions/lint_pkgbuild/pkgname.sh
@@ -30,7 +30,9 @@ lint_pkgbuild_functions+=('lint_pkgname')
 
 
 lint_one_pkgname() {
-	local type=$1 name=$2 ret=0 remaining_prefix
+	local name="${1}"
+	local type="${2}"
+	local ret=0
 
 	if [[ -z $name ]]; then
 		error "$(gettext "%s is not allowed to be empty.")" "$type"
@@ -53,14 +55,7 @@ lint_one_pkgname() {
 	fi
 	
 	# These first two need to be put into 'depends.sh' and 'optdepends.sh' respectively.
-	if [[ "${type}" == "depends" ]]; then
-		if ! check_prefix prefix "${name}" 'p!'; then
-			error "$(gettext "%s contains an invalid prefix: '%s'")" "${type}" "${prefix}"
-			return 1
-		fi
-		strip_prefix name "${name}"
-		
-	elif [[ "${type}" == "optdepends" ]]; then
+	if [[ "${type}" == "optdepends" ]]; then
 		if ! check_prefix prefix "${name}" 'r!' 's!'; then
 			error "$(gettext "%s contains an invalid prefix: '%s'")" "${type}" "${prefix}"
 			return 1
@@ -91,7 +86,7 @@ lint_pkgname() {
 		ret=1
 	else
 		for i in "${pkgname[@]}"; do
-			lint_one_pkgname "pkgname" "$i" || ret=1
+			lint_one_pkgname "$i" 'pkgname' || ret=1
 		done
 	fi
 

--- a/src/functions/lint_pkgbuild/provides.sh
+++ b/src/functions/lint_pkgbuild/provides.sh
@@ -33,29 +33,5 @@ lint_pkgbuild_functions+=('lint_provides')
 
 
 lint_provides() {
-	local provides_list provide name ver ret=0
-
-	get_pkgbuild_all_split_attributes provides provides_list
-
-	# this function requires extglob - save current status to restore later
-	local shellopts=$(shopt -p extglob)
-	shopt -s extglob
-
-	for provide in "${provides_list[@]}"; do
-		if [[ $provide == *['<>']* ]]; then
-			error "$(gettext "%s array cannot contain comparison (< or >) operators.")" "provides"
-			ret=1
-			continue
-		fi
-		name=${provide%=*}
-		lint_one_pkgname provides "$name" || ret=1
-		if [[ $name != "$provide" ]]; then
-			ver=${provide##$name=}
-			check_fullpkgver "$ver" provides || ret=1
-		fi
-	done
-
-	eval "$shellopts"
-
-	return $ret
+	lint_deps 'provides' '' || return 1
 }

--- a/src/functions/util/message.sh
+++ b/src/functions/util/message.sh
@@ -88,3 +88,8 @@ error() {
 	local mesg=$1; shift
 	printf "${RED}[!]${ALL_OFF}${BOLD} ${mesg}${ALL_OFF}\n" "$@" >&2
 }
+
+error2() {
+  local mesg=$1; shift
+  printf "${RED}  [->]${ALL_OFF}${BOLD} ${mesg}${ALL_OFF}\n" "$@" >&2
+}

--- a/src/functions/util/pkgbuild.sh
+++ b/src/functions/util/pkgbuild.sh
@@ -287,7 +287,12 @@ get_integlist() {
 # Get all occurances of a variable plus it's extensions (i.e. for 'depends',
 # 'depends' and 'focal_depends').
 get_extended_variables() {
-	printf '%s\n' "${env_keys[@]}" | grep -F "${1}" | head -c -1
+	printf '%s\n' "${env_keys[@]}" | grep -F "_${1}" | head -c -1
+	printf '%s\n' "${env_keys[@]}" | grep -F "${1}_" | head -c -1
+
+	if in_array "${1}" "${env_keys[@]}"; then
+		echo "${1}"
+	fi
 }
 
 # Split a dependency by it's pipe character, i.e.

--- a/src/functions/util/pkgbuild.sh
+++ b/src/functions/util/pkgbuild.sh
@@ -283,3 +283,15 @@ get_integlist() {
 		printf "%s\n" "${INTEGRITY_CHECK[@]}"
 	fi
 }
+
+# Get all occurances of a variable plus it's extensions (i.e. for 'depends',
+# 'depends' and 'focal_depends').
+get_extended_variables() {
+	printf '%s\n' "${env_keys[@]}" | grep -F "${1}" | head -c -1
+}
+
+# Split a dependency by it's pipe character, i.e.
+# 'hi|me' -> 'hi' and 'me' returned.
+split_dep_by_pipe() {
+	echo "${1}" | sed 's/|/\n/g' | head -c -1
+}

--- a/src/main.sh
+++ b/src/main.sh
@@ -447,26 +447,6 @@ write_extra_control_fields() {
 
 write_control_info() {
 	local fullver=$(get_full_version)
-	local new_predepends
-	local new_depends
-	local new_recommends
-	local new_suggests
-	local new_conflicts
-	local new_provides
-	local new_replaces
-	local new_breaks
-
-	remove_optdepends_description clean_recommends "${recommends[@]}"
-	remove_optdepends_description clean_suggests "${suggests[@]}"
-
-	convert_relationships new_predepends "${predepends[@]}"
-	convert_relationships new_depends "${depends[@]}"
-	convert_relationships new_recommends "${clean_recommends[@]}"
-	convert_relationships new_suggests "${clean_suggests[@]}"
-	convert_relationships new_conflicts "${conflicts[@]}"
-	convert_relationships new_provides "${provides[@]}"
-	convert_relationships new_replaces "${replaces[@]}"
-	convert_relationships new_breaks "${breaks[@]}"
 
 	write_control_pair "Package" "${pkgname}"
 	write_control_pair "Version" "${fullver}"
@@ -475,14 +455,14 @@ write_control_info() {
 	write_control_pair "License" "${license[@]}"
 	write_control_pair "Maintainer" "${maintainer}"
 	write_control_pair "Homepage" "${url}"
-	write_control_pair "Pre-Depends" "${new_predepends[@]}"
-	write_control_pair "Depends" "${new_depends[@]}"
-	write_control_pair "Recommends" "${new_recommends[@]}"
-	write_control_pair "Suggests" "${new_suggests[@]}"
-	write_control_pair "Conflicts" "${new_conflicts[@]}"
-	write_control_pair "Provides" "${new_provides[@]}"
-	write_control_pair "Replaces" "${new_replaces[@]}"
-	write_control_pair "Breaks" "${new_breaks[@]}"
+	write_control_pair "Pre-Depends" "${predepends[@]}"
+	write_control_pair "Depends" "${depends[@]}"
+	write_control_pair "Recommends" "${recommends[@]}"
+	write_control_pair "Suggests" "${suggests[@]}"
+	write_control_pair "Conflicts" "${conflicts[@]}"
+	write_control_pair "Provides" "${provides[@]}"
+	write_control_pair "Replaces" "${replaces[@]}"
+	write_control_pair "Breaks" "${breaks[@]}"
 	write_extra_control_fields
 }
 
@@ -1163,6 +1143,18 @@ check_distro_dependencies
 # Convert needed dependencies.
 convert_dependencies
 
+remove_optdepends_description recommends "${recommends[@]}"
+remove_optdepends_description suggests "${suggests[@]}"
+
+convert_relationships predepends "${predepends[@]}"
+convert_relationships depends "${depends[@]}"
+convert_relationships recommends "${clean_recommends[@]}"
+convert_relationships suggests "${clean_suggests[@]}"
+convert_relationships conflicts "${conflicts[@]}"
+convert_relationships provides "${provides[@]}"
+convert_relationships replaces "${replaces[@]}"
+convert_relationships breaks "${breaks[@]}"
+
 if (( PRINTCONTROL )); then
 	output=""
 
@@ -1244,6 +1236,8 @@ if (( NODEPS || ( VERIFYSOURCE && !SYNCDEPS ) )); then
 else
 	msg "$(gettext "Checking for missing dependencies...")"
 	check_missing_dependencies
+
+	exit 1
 
 	if ! (( "${SYNCDEPS}" )); then
 		verify_no_missing_dependencies || exit "${E_INSTALL_DEPS_FAILED}"

--- a/src/main.sh
+++ b/src/main.sh
@@ -450,6 +450,7 @@ write_extra_control_fields() {
 write_control_info() {
 	local fullver=$(get_full_version)
 
+
 	write_control_pair "Package" "${pkgname}"
 	write_control_pair "Version" "${fullver}"
 	write_control_pair "Description" "${pkgdesc}"
@@ -1179,8 +1180,8 @@ remove_optdepends_description suggests "${suggests[@]}"
 
 convert_relationships predepends "${predepends[@]}"
 convert_relationships depends "${depends[@]}"
-convert_relationships recommends "${clean_recommends[@]}"
-convert_relationships suggests "${clean_suggests[@]}"
+convert_relationships recommends "${recommends[@]}"
+convert_relationships suggests "${suggests[@]}"
 convert_relationships conflicts "${conflicts[@]}"
 convert_relationships provides "${provides[@]}"
 convert_relationships replaces "${replaces[@]}"

--- a/src/main.sh
+++ b/src/main.sh
@@ -1007,8 +1007,10 @@ unset "${!cksums_@}" "${!md5sums_@}" "${!sha1sums_@}" "${!sha224sums_@}"
 unset "${!sha256sums_@}" "${!sha384sums_@}" "${!sha512sums_@}" "${!b2sums_@}"
 
 # Read environment variables.
-mapfile -t env_vars < <(set | grep '^[^= ]*=')
-mapfile -t env_keys < <(printf '%s\n' "${env_vars[@]}" | grep -o '^[^=]*')
+# We don't process variables that start with '_', as those are meant for custom
+# user-defined variables.
+mapfile -t env_vars < <(set | grep '^[^= ]*=' | grep '^[^_]')
+mapfile -t env_keys < <(printf '%s\n' "${env_vars[@]}" | grep -o '^[^=]*' | grep '^[^_]')
 
 # Unset distro-specific environment variables from a user's environment variables.
 # This processes distro-specific global variables (i.e. 'focal_depends') as well
@@ -1045,8 +1047,8 @@ else
 fi
 
 # Re-read environment variables.
-mapfile -t env_vars < <(set | grep '^[^= ]*=')
-mapfile -t env_keys < <(printf '%s\n' "${env_vars[@]}" | grep -o '^[^=]*')
+mapfile -t env_vars < <(set | grep '^[^= ]*=' | grep '^[^_]')
+mapfile -t env_keys < <(printf '%s\n' "${env_vars[@]}" | grep -o '^[^=]*' | grep '^[^_]')
 
 # Set pkgbase variable if the user didn't define it.
 # We don't set to 'pkgbase' yet so that we don't lint that variable when the user didn't set it.

--- a/test/tests/checkdepends.bats
+++ b/test/tests/checkdepends.bats
@@ -49,7 +49,6 @@ load ../util/util
     pkgbuild array checkdepends 'z!bats'
     pkgbuild clean
     run makedeb -d
-    echo "${output}" >&3
     [[ "${status}" == "12" ]]
-    [[ "${output}" == "Dependency 'z!bats' under 'checkdepends' contains an invalid prefix: 'z'" ]]
+    [[ "${output}" == "[!] Dependency 'z!bats' under 'checkdepends' contains an invalid prefix: 'z'" ]]
 }

--- a/test/tests/checkdepends.bats
+++ b/test/tests/checkdepends.bats
@@ -50,5 +50,5 @@ load ../util/util
     pkgbuild clean
     run makedeb -d
     [[ "${status}" == "12" ]]
-    [[ "${output}" == "[!] checkdepends contains invalid characters: '!'" ]]
+    [[ "${output}" == "Dependency 'z!bats' under 'checkdepends' contains an invalid prefix: 'z'" ]]
 }

--- a/test/tests/checkdepends.bats
+++ b/test/tests/checkdepends.bats
@@ -49,6 +49,7 @@ load ../util/util
     pkgbuild array checkdepends 'z!bats'
     pkgbuild clean
     run makedeb -d
+    echo "${output}" >&3
     [[ "${status}" == "12" ]]
     [[ "${output}" == "Dependency 'z!bats' under 'checkdepends' contains an invalid prefix: 'z'" ]]
 }

--- a/test/tests/depends.bats
+++ b/test/tests/depends.bats
@@ -66,5 +66,5 @@ load ../util/util
     pkgbuild clean
     run makedeb -d
     [[ "${status}" == "12" ]]
-    [[ "${output}" == "[!] depends contains an invalid prefix: 'z!'" ]]
+    [[ "${output}" == "[!] Dependency 'z!bats' under 'depends' contains an invalid prefix: 'z'" ]]
 }

--- a/test/tests/makedepends.bats
+++ b/test/tests/makedepends.bats
@@ -68,5 +68,5 @@ load ../util/util
     pkgbuild clean
     run makedeb -d
     [[ "${status}" == "12" ]]
-    [[ "${output}" == "[!] makedepends contains invalid characters: '!'" ]]
+    [[ "${output}" == "[!] Dependency 'z!bats' under 'makedepends' contains an invalid prefix: 'z'" ]]
 }

--- a/test/tests/optdepends.bats
+++ b/test/tests/optdepends.bats
@@ -52,5 +52,5 @@ load ../util/util
     pkgbuild clean
     run makedeb -d
     [[ "${status}" == "12" ]]
-    [[ "${output}" == "[!] optdepends contains an invalid prefix: 'z!'" ]]
+    [[ "${output}" == "[!] Dependency 'z!bats' under 'optdepends' contains an invalid prefix: 'z'" ]]
 }

--- a/test/tests/provides.bats
+++ b/test/tests/provides.bats
@@ -25,5 +25,5 @@ load ../util/util
     pkgbuild clean
     run makedeb -d
     [[ "${status}" == "12" ]]
-    [[ "${output}" == "Version restrictor '>=' in 'bats>=0' isn't allowed on 'provides'." ]]
+    [[ "${output}" == "[!] Version restrictor '>=' in 'bats>=0' isn't allowed on 'provides'." ]]
 }

--- a/test/tests/provides.bats
+++ b/test/tests/provides.bats
@@ -25,5 +25,5 @@ load ../util/util
     pkgbuild clean
     run makedeb -d
     [[ "${status}" == "12" ]]
-    [[ "${output}" == 'Version restrictor '>=' in 'bats>=0' isn't allowed on 'provides'.' ]]
+    [[ "${output}" == "Version restrictor '>=' in 'bats>=0' isn't allowed on 'provides'." ]]
 }

--- a/test/tests/provides.bats
+++ b/test/tests/provides.bats
@@ -25,5 +25,5 @@ load ../util/util
     pkgbuild clean
     run makedeb -d
     [[ "${status}" == "12" ]]
-    [[ "${output}" == '[!] provides array cannot contain comparison (< or >) operators.' ]]
+    [[ "${output}" == 'Version restrictor '>=' in 'bats>=0' isn't allowed on 'provides'.' ]]
 }


### PR DESCRIPTION
This adds support for declaring pipe characters to separate a list of dependencies to choose to install from.

Considering this example:
```sh
depends=(
    'pkg1|pkg2<=5|pkg3'
)
```

It would end up converted to the following in the built package:

```
Depends: pkg1 | pkg2 (<= 5) | pkg3
```