### PR TITLE
Fix '--no-confirm' not working properly

### DIFF
--- a/.data.json
+++ b/.data.json
@@ -1,8 +1,8 @@
 {
-    "current_pkgver": "14.0.0",
+    "current_pkgver": "14.0.1",
     "current_pkgrel_stable": "stable",
-    "current_pkgrel_beta": "beta4",
-    "current_pkgrel_alpha": "alpha14",
+    "current_pkgrel_beta": "beta",
+    "current_pkgrel_alpha": "alpha",
     "makedeb_man_epoch": "1635393570",
     "pkgbuild_man_epoch": "1649142725"
 }

--- a/src/functions/dependencies/install_missing_dependencies.sh
+++ b/src/functions/dependencies/install_missing_dependencies.sh
@@ -4,11 +4,13 @@ install_missing_dependencies() {
     fi
 
     msg2 "Installing required build dependencies..."
-
-    if ! sudo apt-get satisfy "${apt_args[@]}" -- "${missing_dependencies[@]}" "${missing_build_dependencies[@]}"; then
+    
+    set -x
+    if ! sudo apt-get satisfy "${APTARGS[@]}" -- "${missing_dependencies[@]}" "${missing_build_dependencies[@]}"; then
         error "There was an error installing build dependencies."
         return 1
     fi
+    set +x
 
     if ! sudo apt-mark auto -- "${missing_dependencies_no_relations[@]}" "${missing_build_dependencies_no_relations[@]}" 1> /dev/null; then
         error "There was an error marking installed build dependencies as automatically installed."

--- a/src/functions/dependencies/remove_installed_dependencies.sh
+++ b/src/functions/dependencies/remove_installed_dependencies.sh
@@ -5,7 +5,7 @@ remove_installed_dependencies() {
 
     msg "Removing installed build dependencies..."
 
-    if ! sudo apt-get purge "${apt_args[@]}" -- "${missing_build_dependencies_no_relations[@]}"; then
+    if ! sudo apt-get purge "${APTARGS[@]}" -- "${missing_build_dependencies_no_relations[@]}"; then
         error "There was an error removing build dependencies."
         exit 1
     fi

--- a/src/main.sh
+++ b/src/main.sh
@@ -681,8 +681,8 @@ install_package() {
 		pkgarch=$(get_pkg_arch $pkg)
 		pkglist+=("${PKGDEST}/${pkg}_${fullver}_${pkgarch}.deb")
 	done
-
-	if ! sudo apt-get reinstall "${APTARGS[@]}" -- "${pkglist[@]}"; then
+	
+	if ! sudo apt-get install --reinstall "${APTARGS[@]}" -- "${pkglist[@]}"; then
 		warning "$(gettext "Failed to install built package(s).")"
 		return $E_INSTALL_FAILED
 	fi


### PR DESCRIPTION
'--no-confirm' didn't work previously when installing dependencies due to a mistyped variable name when transferring code from dd44bc237b28ebc0b2dcfb4036f55ef5cc888c01.