### PR TITLE
Revert ZSTD support

### DIFF
--- a/.data.json
+++ b/.data.json
@@ -1,5 +1,5 @@
 {
-    "current_pkgver": "14.0.1",
+    "current_pkgver": "14.0.2",
     "current_pkgrel_stable": "stable",
     "current_pkgrel_beta": "beta",
     "current_pkgrel_alpha": "alpha",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Note that the `[Unreleased]` section contains all changes that haven't yet made 
 ### Added
 - Added support for custom installing directories during builds (#61).
 
+## [14.0.2] - 2022-04-19
+### Fixed
+- Revert ZSTD support in built archives, as Debian 11 doesn't support them (#158).
+
+## [14.0.1] - 2022-04-19
+### Fixed
+-  Fix '--no-confirm' not working properly during builds (#157).
+
 ## [14.0.0] - 2022-04-16
 ### Added
 - Added `BUILDING.md`.

--- a/src/functions/dependencies/install_missing_dependencies.sh
+++ b/src/functions/dependencies/install_missing_dependencies.sh
@@ -5,12 +5,10 @@ install_missing_dependencies() {
 
     msg2 "Installing required build dependencies..."
     
-    set -x
     if ! sudo apt-get satisfy "${APTARGS[@]}" -- "${missing_dependencies[@]}" "${missing_build_dependencies[@]}"; then
         error "There was an error installing build dependencies."
         return 1
     fi
-    set +x
 
     if ! sudo apt-mark auto -- "${missing_dependencies_no_relations[@]}" "${missing_build_dependencies_no_relations[@]}" 1> /dev/null; then
         error "There was an error marking installed build dependencies as automatically installed."

--- a/src/main.sh
+++ b/src/main.sh
@@ -545,7 +545,7 @@ create_package() {
 	mv control.tar.gz ../
 	cd ../
 
-	mapfile -t package_files < <(find ./ -mindepth 1 -maxdepth 1 -not -path "./DEBIAN" -not -path './debian-binary' -not -path './control.tar')
+	mapfile -t package_files < <(find ./ -mindepth 1 -maxdepth 1 -not -path "./DEBIAN" -not -path './debian-binary' -not -path './control.tar.gz')
 
 	# Tar doesn't like no files being provided for an archive.
 	if [[ "${#package_files[@]}" == 0 ]]; then

--- a/src/main.sh
+++ b/src/main.sh
@@ -486,9 +486,6 @@ write_control_info() {
 }
 
 create_package() {
-	zstdthreads=0
-	zstdlevel=10
-
 	if [[ ! -d $pkgdir ]]; then
 		error "$(gettext "Missing %s directory.")" "\$pkgdir/"
 		plainerr "$(gettext "Aborting...")"
@@ -544,25 +541,21 @@ create_package() {
 
 	cd DEBIAN/
 	mapfile -t control_files < <(find ./ -mindepth 1 -maxdepth 1)
-	tar -cf ./control.tar "${control_files[@]}"
-	mv control.tar ../
+	tar -czf ./control.tar.gz "${control_files[@]}"
+	mv control.tar.gz ../
 	cd ../
 
 	mapfile -t package_files < <(find ./ -mindepth 1 -maxdepth 1 -not -path "./DEBIAN" -not -path './debian-binary' -not -path './control.tar')
 
 	# Tar doesn't like no files being provided for an archive.
 	if [[ "${#package_files[@]}" == 0 ]]; then
-		tar -cf ./data.tar --files-from /dev/null
+		tar -cf ./data.tar.gz --files-from /dev/null
 	else
-		tar -cf ./data.tar "${package_files[@]}"
+		tar -cf ./data.tar.gz "${package_files[@]}"
 	fi
 	
-	for archive in 'control.tar' 'data.tar'; do
-		zstd "-T${zstdthreads}" "-${zstdlevel}" --rm -q "${archive}"
-	done
-
-	ar -rU "${pkg_file}" debian-binary control.tar.zst data.tar.zst 2> /dev/null
-	rm debian-binary control.tar.zst data.tar.zst
+	ar -rU "${pkg_file}" debian-binary control.tar.gz data.tar.gz 2> /dev/null
+	rm debian-binary control.tar.gz data.tar.gz
 }
 
 create_debug_package() {

--- a/test/tests/archive.bats
+++ b/test/tests/archive.bats
@@ -13,7 +13,7 @@ load ../util/util
     makedeb -d
 
     ar xf testpkg_1.0.0-1_all.deb
-    mapfile -t files < <(tar tf control.tar.zst | sort -V)
+    mapfile -t files < <(tar tf control.tar.gz | sort -V)
     mapfile -t expected_files < <(printf '%s\n' './control' './preinst' | sort -V)
 
     [[ "${#files[@]}" == "${#expected_files[@]}" ]]


### PR DESCRIPTION
Debian 11 doesn't appear to support ZSTD as a compression algorithm, which is a problem since makedeb supports the latest Debian LTS and Ubuntu LTS. Likewise, we're going back to using Gzip for compression until we can get ZSTD support behind a config option.