### PR TITLE
Clone all refs for Git sources in PKGBUILDs

### DIFF
--- a/.data.json
+++ b/.data.json
@@ -1,5 +1,5 @@
 {
-    "current_pkgver": "14.0.2",
+    "current_pkgver": "14.0.3",
     "current_pkgrel_stable": "stable",
     "current_pkgrel_beta": "beta",
     "current_pkgrel_alpha": "alpha",

--- a/src/functions/source/git.sh
+++ b/src/functions/source/git.sh
@@ -66,13 +66,13 @@ download_git() {
 	if [[ ! -d "$dir" ]] || dir_is_empty "$dir" ; then
 		msg2 "$(gettext "Cloning %s %s repo...")" "${repo}" "git"
 		if [[ $ref != "origin/HEAD" ]] || (( updating )) ; then
-			if ! git clone --depth 1 --branch "${ref}" "$url" "$dir"; then
+			if ! git clone --depth 1 --no-single-branch --branch "${ref}" "$url" "$dir"; then
 				error "$(gettext "Failure while downloading %s %s repo")" "${repo}" "git"
 				plainerr "$(gettext "Aborting...")"
 				exit 1
 			fi
 		else
-			if ! git clone --depth 1 "$url" "$dir"; then
+			if ! git clone --depth 1 --no-single-branch "$url" "$dir"; then
 				error "$(gettext "Failure while downloading %s %s repo")" "${repo}" "git"
 				plainerr "$(gettext "Aborting...")"
 				exit 1

--- a/test/tests/source.bats
+++ b/test/tests/source.bats
@@ -87,7 +87,7 @@ load ../util/util
 @test "correct source - ensure tags are cloned" {
     pkgbuild string maintainer1 'Foo Bar <foo@bar.com>'
     pkgbuild string pkgname testpkg
-    pkgbuild string pkver 1.0.0
+    pkgbuild string pkgver 1.0.0
     pkgbuild string pkgrel 1
     pkgbuild string pkgdesc 'package description'
     pkgbuild array arch any

--- a/test/tests/source.bats
+++ b/test/tests/source.bats
@@ -83,3 +83,19 @@ load ../util/util
     run makedeb -d
     [[ "${status}" == "1" ]]
 }
+
+@test "correct source - ensure tags are cloned" {
+    pkgbuild string maintainer1 'Foo Bar <foo@bar.com>'
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild string pkgdesc 'package description'
+    pkgbuild array arch any
+    pkgbuild array source 'git+https://github.com/makedeb/makedeb'
+    pkgbuild array sha256sums 'SKIP'
+    pkgbuild clean
+    makedeb -d
+
+    mapfile -t tags < <(cd src/makedeb; git tag)
+    [[ "${#tags[@]}" -gt 0 ]]
+}


### PR DESCRIPTION
We only cloned the specified commit previously, which causes issues if the packager decides to use tags in 'pkgver()' or something similar in their PKGBUILD.

The plan is to make the previous system the default later, and to just allow cloning tags via a config option.