### PR TITLE
Fix unknown error when checking hashsums with '--skip-pgp-check'

### DIFF
--- a/.data.json
+++ b/.data.json
@@ -1,5 +1,5 @@
 {
-    "current_pkgver": "14.0.3",
+    "current_pkgver": "14.0.4",
     "current_pkgrel_stable": "stable",
     "current_pkgrel_beta": "beta",
     "current_pkgrel_alpha": "alpha",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note that the `[Unreleased]` section contains all changes that haven't yet made 
 ### Added
 - Added support for custom installing directories during builds (#61).
 
+## [14.0.4] - 2022-04-29
+### Fixed
+- Fix unknown error when checking hashsums with `--skip-pgp-check`
+
 ## [14.0.2] - 2022-04-19
 ### Fixed
 - Revert ZSTD support in built archives, as Debian 11 doesn't support them (#158).

--- a/src/functions/integrity/verify_checksum.sh
+++ b/src/functions/integrity/verify_checksum.sh
@@ -47,7 +47,9 @@ check_checksums() {
 	fi
 
 	for integ in "${known_hash_algos[@]}"; do
-		in_array "${distro}${integ}sums${arch_name}" "${env_keys[@]}" && verify_integrity_sums "${distro}source${arch_name}" "${distro}${integ}sums${arch_name}" "${integ}"
+		if in_array "${distro}${integ}sums${arch_name}" "${env_keys[@]}"; then
+			verify_integrity_sums "${distro}source${arch_name}" "${distro}${integ}sums${arch_name}" "${integ}"
+		fi
 	done
 }
 


### PR DESCRIPTION
We had an 'in_array' command at the end of a function, which returned a non-0 exit code when it couldn't find the specified array element. For some reason this issue only happens when '--skip-pgp-check' is used, though I'm not sure why at the moment.