### PR TITLE
Fix dependencies not being separated by a comma in control files

### DIFF
--- a/.data.json
+++ b/.data.json
@@ -2,7 +2,7 @@
     "current_pkgver": "14.1.3",
     "current_pkgrel_stable": "stable",
     "current_pkgrel_beta": "beta",
-    "current_pkgrel_alpha": "alpha1",
+    "current_pkgrel_alpha": "alpha2",
     "makedeb_man_epoch": "1635393570",
     "pkgbuild_man_epoch": "1649142725"
 }

--- a/src/functions/dependencies/convert_relationships.sh
+++ b/src/functions/dependencies/convert_relationships.sh
@@ -44,10 +44,10 @@ convert_relationships() {
         if [[ "${#pkglist[@]}" == 1 ]]; then
             new_values+=("${pkglist[@]}")
         else
-            new_values+="$(printf '%s\n' "${pkglist[@]}" | sed 's/.*/& | /' | tac | rev | sed '1s/ | //' | rev | tac | tr -d '\n')"
+            new_values+=("$(printf '%s\n' "${pkglist[@]}" | sed 's/.*/& | /' | tac | rev | sed '1s/ | //' | rev | tac | tr -d '\n')")
         fi
     done
-    
+
     create_array "${target_var}" "${new_values[@]}"
 }
 

--- a/test/tests/depends.bats
+++ b/test/tests/depends.bats
@@ -55,6 +55,20 @@ load ../util/util
     [[ "$(cat pkg/testpkg/DEBIAN/control | grep '^Depends:')" == "Depends: bash" ]]
 }
 
+@test "correct depends - separate by pipe" {
+    pkgbuild string maintainer1 'Foo Bar <foo@bar.com>'
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild string pkgdesc "package description"
+    pkgbuild array arch any
+    pkgbuild array depends 'pkg1|pkg2' 'pkg3>=2|pkg4=6'
+    pkgbuild clean
+    run -0 makedeb --print-control
+    [[ "$(echo "${output}" | grep '^Depends:')" == 'Depends: pkg1 | pkg2, pkg3 (>= 2) | pkg4 (= 6)' ]]
+}
+
+
 @test "incorrect depends - invalid dependency prefix" {
     pkgbuild string maintainer1 'Foo Bar <foo@bar.com>'
     pkgbuild string pkgname testpkg

--- a/test/tests/depends.bats
+++ b/test/tests/depends.bats
@@ -65,6 +65,7 @@ load ../util/util
     pkgbuild array depends 'pkg1|pkg2' 'pkg3>=2|pkg4=6'
     pkgbuild clean
     run -0 makedeb --print-control
+    echo "${output}" | grep '^Depends:' >&3
     [[ "$(echo "${output}" | grep '^Depends:')" == 'Depends: pkg1 | pkg2, pkg3 (>= 2) | pkg4 (= 6)' ]]
 }
 

--- a/test/tests/depends.bats
+++ b/test/tests/depends.bats
@@ -68,7 +68,6 @@ load ../util/util
     [[ "$(echo "${output}" | grep '^Depends:')" == 'Depends: pkg1 | pkg2, pkg3 (>= 2) | pkg4 (= 6)' ]]
 }
 
-
 @test "incorrect depends - invalid dependency prefix" {
     pkgbuild string maintainer1 'Foo Bar <foo@bar.com>'
     pkgbuild string pkgname testpkg

--- a/test/tests/depends.bats
+++ b/test/tests/depends.bats
@@ -64,8 +64,8 @@ load ../util/util
     pkgbuild array arch any
     pkgbuild array depends 'pkg1|pkg2' 'pkg3>=2|pkg4=6'
     pkgbuild clean
-    run -0 makedeb --print-control
-    echo "${output[@]@Q}" >&3
+    run makedeb --print-control
+    [[ "${status}" == 0 ]]
     [[ "$(echo "${output}" | grep '^Depends:')" == 'Depends: pkg1 | pkg2, pkg3 (>= 2) | pkg4 (= 6)' ]]
 }
 

--- a/test/tests/depends.bats
+++ b/test/tests/depends.bats
@@ -65,7 +65,7 @@ load ../util/util
     pkgbuild array depends 'pkg1|pkg2' 'pkg3>=2|pkg4=6'
     pkgbuild clean
     run -0 makedeb --print-control
-    echo "${output}" | grep '^Depends:' >&3
+    echo "${output[@]@Q}" >&3
     [[ "$(echo "${output}" | grep '^Depends:')" == 'Depends: pkg1 | pkg2, pkg3 (>= 2) | pkg4 (= 6)' ]]
 }
 

--- a/test/tests/pkgbase.bats
+++ b/test/tests/pkgbase.bats
@@ -65,7 +65,7 @@ load ../util/util
 
 @test "incorrect pkgbase - invalid character" {
     pkgbuild string maintainer1 'Foo Bar <foo@bar.com>'
-    pkgbuild string pkgbase 'test-%kg'
+    pkgbuild string pkgbase 'test-#kg'
     pkgbuild string pkgname test-pkg
     pkgbuild string pkgver 1.0.0
     pkgbuild string pkgrel 1
@@ -74,7 +74,7 @@ load ../util/util
     pkgbuild clean
     run makedeb -d
     [[ "${status}" == "12" ]]
-    [[ "${output}" == "[!] pkgbase contains invalid characters: '%'" ]]
+    [[ "${output}" == "[!] pkgbase contains invalid characters: '#'" ]]
 }
     
 @test "incorrect pkgbase - array" {

--- a/test/tests/pkgname.bats
+++ b/test/tests/pkgname.bats
@@ -61,7 +61,7 @@ load ../util/util
 @test "incorrect pkgname - disallowed character" {
     pkgbuild string maintainer1 'Foo Bar <foo@bar.com>'
     pkgbuild string pkgbase testpkg
-    pkgbuild string pkgname 'testp%kg'
+    pkgbuild string pkgname 'testp#kg'
     pkgbuild string pkgver 1.0.0
     pkgbuild string pkgrel 1
     pkgbuild string pkgdesc "package description"
@@ -69,5 +69,5 @@ load ../util/util
     pkgbuild clean
     run makedeb -d
     [[ "${status}" == "12" ]]
-    [[ "${output}" == "[!] pkgname contains invalid characters: '%'" ]]
+    [[ "${output}" == "[!] pkgname contains invalid characters: '#'" ]]
 }

--- a/test/tests/pkgver.bats
+++ b/test/tests/pkgver.bats
@@ -28,7 +28,7 @@ load ../util/util
 @test "incorrect pkgver - invalid character" {
     pkgbuild string maintainer1 'Foo Bar <foo@bar.com>'
     pkgbuild string pkgname testpkg
-    pkgbuild string pkgver '1.0.0+al%ha'
+    pkgbuild string pkgver '1.0.0+al#ha'
     pkgbuild string pkgrel 1
     pkgbuild string pkgdesc "package description"
     pkgbuild array arch any

--- a/test/util/util.bash
+++ b/test/util/util.bash
@@ -24,14 +24,14 @@ pkgbuild() {
     if [[ "${cmd}" == "array" ]]; then
         strings="(${strings[@]@Q})"
         # We have to use a character that isn't use by any strings.
-        # For the time being it's a '_', but feel free to change
+        # For the time being it's a '%', but feel free to change
         # this if you face issues in tests.
         sed -i "s_\$\${${variable}}_${strings}_" "${PKGBUILD:-PKGBUILD}"
 
     elif [[ "${cmd}" == "string" ]]; then
         strings="${strings[@]}"
         strings="${strings@Q}"
-        sed -i "s|\$\${${variable}}|${strings}|" "${PKGBUILD:-PKGBUILD}"
+        sed -i "s%\$\${${variable}}%${strings}%" "${PKGBUILD:-PKGBUILD}"
 
     elif [[ "${cmd}" == "function" ]]; then
         if [[ "$(type -t "${variable}")" != 'function' ]]; then

--- a/test/util/util.bash
+++ b/test/util/util.bash
@@ -23,7 +23,10 @@ pkgbuild() {
 
     if [[ "${cmd}" == "array" ]]; then
         strings="(${strings[@]@Q})"
-        sed -i "s|\$\${${variable}}|${strings}|" "${PKGBUILD:-PKGBUILD}"
+        # We have to use a character that isn't use by any strings.
+        # For the time being it's a '_', but feel free to change
+        # this if you face issues in tests.
+        sed -i "s_\$\${${variable}}_${strings}_" "${PKGBUILD:-PKGBUILD}"
 
     elif [[ "${cmd}" == "string" ]]; then
         strings="${strings[@]}"

--- a/test/util/util.bash
+++ b/test/util/util.bash
@@ -26,7 +26,7 @@ pkgbuild() {
         # We have to use a character that isn't use by any strings.
         # For the time being it's a '%', but feel free to change
         # this if you face issues in tests.
-        sed -i "s_\$\${${variable}}_${strings}_" "${PKGBUILD:-PKGBUILD}"
+        sed -i "s%\$\${${variable}}%${strings}%" "${PKGBUILD:-PKGBUILD}"
 
     elif [[ "${cmd}" == "string" ]]; then
         strings="${strings[@]}"


### PR DESCRIPTION
We put all deps into a Bash array, all of which are then separated by a comma during control field generation. Previously we were putting all deps into array index 0 though, due to missing parenthesis that made our array additions only target the first index.