### PR TITLE
Fix bug in makedepends and checkdepends not being installed when using relationships

### DIFF
--- a/.data.json
+++ b/.data.json
@@ -2,7 +2,7 @@
     "current_pkgver": "14.1.3",
     "current_pkgrel_stable": "stable",
     "current_pkgrel_beta": "beta",
-    "current_pkgrel_alpha": "alpha2",
+    "current_pkgrel_alpha": "alpha3",
     "makedeb_man_epoch": "1635393570",
     "pkgbuild_man_epoch": "1649142725"
 }

--- a/src/main.sh
+++ b/src/main.sh
@@ -1188,6 +1188,8 @@ remove_optdepends_description suggests "${suggests[@]}"
 
 convert_relationships predepends "${predepends[@]}"
 convert_relationships depends "${depends[@]}"
+convert_relationships makedepends "${makedepends[@]}"
+convert_relationships checkdepends "${checkdepends[@]}"
 convert_relationships recommends "${recommends[@]}"
 convert_relationships suggests "${suggests[@]}"
 convert_relationships conflicts "${conflicts[@]}"

--- a/test/tests/checkdepends.bats
+++ b/test/tests/checkdepends.bats
@@ -9,20 +9,6 @@ load ../util/util
     pkgbuild array arch any
     pkgbuild array checkdepends 'bats>0' 'bash'
     pkgbuild clean
-    makedeb -d
-}
-
-@test "correct checkdepends - install missing dependencies" {
-    skip "THIS IS CURRENTLY FAILING DUE TO A BUG IN MAKEDEB"
-    sudo_check
-    pkgbuild string maintainer1 'Foo Bar <foo@bar.com>'
-    pkgbuild string pkgname testpkg
-    pkgbuild string pkgver 1.0.0
-    pkgbuild string pkgrel 1
-    pkgbuild string pkgdesc "package description"
-    pkgbuild array arch any
-    pkgbuild array checkdepends 'zsh' 'yash>=0.0.1'
-    pkgbuild clean
     makedeb -s --no-confirm --allow-downgrades
 }
 

--- a/test/tests/makedepends.bats
+++ b/test/tests/makedepends.bats
@@ -9,20 +9,6 @@ load ../util/util
     pkgbuild array arch any
     pkgbuild array makedepends 'bats>0' 'bash'
     pkgbuild clean
-    makedeb -d
-}
-
-@test "correct makedepends - install missing dependencies" {
-    skip "THIS IS CURRENTLY FAILING DUE TO A BUG IN MAKEDEB."
-    sudo_check
-    pkgbuild string maintainer1 'Foo Bar <foo@bar.com>'
-    pkgbuild string pkgname testpkg
-    pkgbuild string pkgver 1.0.0
-    pkgbuild string pkgrel 1
-    pkgbuild string pkgdesc "package description"
-    pkgbuild array arch any
-    pkgbuild array makedepends 'zsh' 'yash>=0.0.1'
-    pkgbuild clean
     makedeb -s --no-confirm --allow-downgrades
 }
 


### PR DESCRIPTION
Previously if we had a makedepends or checkdepends package containing a relationship (i.e. `>=1` in `pkg>=1`), an error was shown and missing deps didn't get installed. This was due to us not converting relationships for `makedepends` or `checkdepends` packages.