### PR TITLE
Add ability to run unit tests locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,3 +48,27 @@ done
 
 ### Indentation
 For indentation, we use four spaces, formatted as space characters. Not all code currently follows this guideline, though all new code needs to follow such.
+
+## Running unit tests
+All PRs on GitHub automatically run through GitHub Actions to ensure that your code is working properly.
+
+If preferred, you can also first run unit tests before pushing your changes though.
+
+### Needed packages
+To run unit tests, you'll need [Toast](https://github.com/stepchowfun/toast) installed.
+
+#### MPR
+Toast is available on the [MPR](https://mpr.makedeb.org/packages/toast) if you'd prefer that:
+
+```sh
+git clone 'https://mpr.makedeb.org/toast'
+cd toast/
+makedeb -si
+```
+
+#### Prebuilt-MPR
+Depending on your system, Toast may take a while to compile. If you'd prefer to have a prebuilt package, you can obtain Toast from the [Prebuilt-MPR](https://docs.makedeb.org/prebuilt-mpr). After setting up the Prebuilt-MPR, just run the following to install Toast:
+
+```sh
+sudo apt install toast
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,13 +52,13 @@ For indentation, we use four spaces, formatted as space characters. Not all code
 ## Running unit tests
 All PRs on GitHub automatically run through GitHub Actions to ensure that your code is working properly.
 
-If preferred, you can also first run unit tests before pushing your changes though.
+If preferred, you can also first run unit tests before pushing your changes.
 
 ### Needed packages
 To run unit tests, you'll need [Toast](https://github.com/stepchowfun/toast) installed.
 
 #### MPR
-Toast is available on the [MPR](https://mpr.makedeb.org/packages/toast) if you'd prefer that. You'll likely also need the latest version of the Rust compiler toolchain, which is also available on the [MPR](https://mpr.makedeb.org/packages/rustc).
+[Toast is available on the MPR](https://mpr.makedeb.org/packages/toast) if you want to install Toast with makedeb. You'll likely also need the latest version of the Rust compiler toolchain, which is [also available on the MPR](https://mpr.makedeb.org/packages/rustc).
 
 ```sh
 # Rust toolchain.
@@ -74,7 +74,7 @@ makedeb -si
 ```
 
 #### Prebuilt-MPR
-Depending on your system, Toast/Rust may take a while to compile. If you'd prefer to have a prebuilt package, you can obtain Toast from the [Prebuilt-MPR](https://docs.makedeb.org/prebuilt-mpr). After setting up the Prebuilt-MPR, just run the following to install Toast:
+Rust and Toast can take a while to build, which some users may wish to avoid. If you'd prefer to have a prebuilt package, which remediates this issue, you can obtain Toast from the [Prebuilt-MPR](https://docs.makedeb.org/prebuilt-mpr). After setting up the Prebuilt-MPR, just run the following to install Toast:
 
 ```sh
 sudo apt install toast

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ If preferred, you can also first run unit tests before pushing your changes thou
 To run unit tests, you'll need [Toast](https://github.com/stepchowfun/toast) installed.
 
 #### MPR
-Toast is available on the [MPR](https://mpr.makedeb.org/packages/toast) if you'd prefer that. You'll likely also need the latest version of the Rust compiler toolchain, which is also available on the [MPR](https://mpr.makedeb.org/rustc).
+Toast is available on the [MPR](https://mpr.makedeb.org/packages/toast) if you'd prefer that. You'll likely also need the latest version of the Rust compiler toolchain, which is also available on the [MPR](https://mpr.makedeb.org/packages/rustc).
 
 ```sh
 # Rust toolchain.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,16 +58,23 @@ If preferred, you can also first run unit tests before pushing your changes thou
 To run unit tests, you'll need [Toast](https://github.com/stepchowfun/toast) installed.
 
 #### MPR
-Toast is available on the [MPR](https://mpr.makedeb.org/packages/toast) if you'd prefer that:
+Toast is available on the [MPR](https://mpr.makedeb.org/packages/toast) if you'd prefer that. You'll likely also need the latest version of the Rust compiler toolchain, which is also available on the [MPR](https://mpr.makedeb.org/rustc).
 
 ```sh
+# Rust toolchain.
+# Note that this may take several hours to build.
+git clone 'https://mpr.makedeb.org/rustc'
+cd rustc/
+makedeb -si
+
+# Toast.
 git clone 'https://mpr.makedeb.org/toast'
 cd toast/
 makedeb -si
 ```
 
 #### Prebuilt-MPR
-Depending on your system, Toast may take a while to compile. If you'd prefer to have a prebuilt package, you can obtain Toast from the [Prebuilt-MPR](https://docs.makedeb.org/prebuilt-mpr). After setting up the Prebuilt-MPR, just run the following to install Toast:
+Depending on your system, Toast/Rust may take a while to compile. If you'd prefer to have a prebuilt package, you can obtain Toast from the [Prebuilt-MPR](https://docs.makedeb.org/prebuilt-mpr). After setting up the Prebuilt-MPR, just run the following to install Toast:
 
 ```sh
 sudo apt install toast

--- a/toast.yml
+++ b/toast.yml
@@ -1,0 +1,17 @@
+image: proget.hunterwittenborn.com/docker/makedeb/makedeb:ubuntu-focal
+user: makedeb
+location: /home/makedeb/makedeb
+command_prefix: set -e
+tasks:
+  install_dependencies:
+    input_paths:
+      - .drone/scripts/install-deps.sh
+    command: .drone/scripts/install-deps.sh
+
+  run_unit_tests:
+    input_paths:
+      - ./
+    command: |
+      sudo chown 'makedeb:makedeb' "${HOME}/makedeb" -R
+      git remote set-url origin 'https://github.com/makedeb/makedeb'
+      release_type=alpha .drone/scripts/run-unit-tests.sh


### PR DESCRIPTION
We need to wait for [`rustc`](https://mpr.makedeb.org/packages/rustc) and [`toast`](https://mpr.makedeb.org/packages/toast) to enter the Prebuilt-MPR before this gets merged.
