### PR TITLE
Add workaround for Python-APT bug

### DIFF
--- a/.data.json
+++ b/.data.json
@@ -1,8 +1,8 @@
 {
     "current_pkgver": "14.1.3",
     "current_pkgrel_stable": "stable",
-    "current_pkgrel_beta": "beta",
-    "current_pkgrel_alpha": "alpha6",
+    "current_pkgrel_beta": "beta1",
+    "current_pkgrel_alpha": "alpha7",
     "makedeb_man_epoch": "1635393570",
     "pkgbuild_man_epoch": "1649142725"
 }

--- a/src/main.sh
+++ b/src/main.sh
@@ -1296,6 +1296,14 @@ if (( NODEPS || ( VERIFYSOURCE && !SYNCDEPS ) )); then
 else
 	msg "$(gettext "Checking for missing dependencies...")"
 	# We need to tell our call to the Python script where makedeb is located because we might need to call it in order to print messages.
+	#
+	# TODO: I'm suspecting there's some kind of bug in the Python APT library. This is being suspected due to the following:
+	# On Ubuntu 20.04, do *not* have libgcc1 installed, but *do* have libgcc-s1 installed.
+	# Running 'apt-get satisfy libgcc1' works as expected, as libgcc-s1 provides libgcc1.
+	# On the other hand, attempting to view the provided package list for libgcc1 isn't showing
+	# libgcc-s1 anywhere. On that note, we gotta be a bit more cautious with the results of our
+	# script, and put more checks into place, such as checking if we actually installed any new
+	# packages before running 'apt-mark auto'.
 	if ! mapfile -t missing_deps < <(MAKEDEB="${0}" "${LIBRARY}/dependencies/missing_apt_dependencies.py" "${predepends[@]}" "${depends[@]}" "${makedepends[@]}" "${checkdepends[@]}"); then
 		error "$(gettext "Failed to check missing dependencies.")"
 		exit "${E_INSTALL_DEPS_FAILED}"
@@ -1319,16 +1327,19 @@ else
 			mapfile -t newly_installed_packages < <(comm -13 --nocheck-order <(printf '%s\n' "${prev_installed_packages[@]}") <(dpkg-query -Wf '${Package}\n' | sort))
 
 			# Mark newly installed packages as automatically installed.
+			# We have to make sure 'newly_installed_packages' isn't empty due to the aformentioned bug above the Python script call.
 			msg "$(gettext "Marking newly installed packages as automatically installed...")"
-			if ! sudo apt-mark auto "${newly_installed_packages[@]}" 1> /dev/null; then
-				error "$(gettext "Failed to mark installed dependencies as automatically installed.")"
-				error "$(gettext "You may need to run 'apt-mark auto' with the following packages:")"
+			if [[ "${#newly_installed_packages[@]}" != 0 ]]; then
+				if ! return sudo apt-mark auto "${newly_installed_packages[@]}" 1> /dev/null; then
+					error "$(gettext "Failed to mark installed dependencies as automatically installed.")"
+					error "$(gettext "You may need to run 'apt-mark auto' with the following packages:")"
 
-				for pkg in "${newly_installed_packages[@]}"; do
-					error2 "${pkg}"
-				done
+					for pkg in "${newly_installed_packages[@]}"; do
+						error2 "${pkg}"
+					done
 
-				exit "${E_INSTALL_DEPS_FAILED}"
+					exit "${E_INSTALL_DEPS_FAILED}"
+				fi
 			fi
 
 			unset prev_installed_packages cur_installed_packages newly_installed_packages


### PR DESCRIPTION
I think we might've encountered a bug with the Python-APT library where provided packages aren't being shown properly. I'm not positive, but this at the least provides a workaround for it.
