### PR TITLE
Convert relationship operators for dependencies defined in 'package()'

### DIFF
--- a/.data.json
+++ b/.data.json
@@ -1,5 +1,5 @@
 {
-    "current_pkgver": "15.0.0",
+    "current_pkgver": "15.0.1",
     "current_pkgrel_stable": "stable",
     "current_pkgrel_beta": "beta",
     "current_pkgrel_alpha": "alpha",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Note that the `[Unreleased]` section contains all changes that haven't yet made 
 
 ## [Unreleased]
 
+## [15.0.1] - 2022-05-25
+### Fixed
+- Convert relationship operators for dependencies defined in `package()`.
+
 ## [15.0.0] - 2022-05-22
 ### Changed
 - Require `pkgver` to start with a digit (#186).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Note that the `[Unreleased]` section contains all changes that haven't yet made 
 
 ## [15.0.1] - 2022-05-25
 ### Fixed
-- Convert relationship operators for dependencies defined in `package()`.
+- Convert relationship operators for dependencies defined in `package()` (#191).
 
 ## [15.0.0] - 2022-05-22
 ### Changed

--- a/src/functions/lint_package.sh
+++ b/src/functions/lint_package.sh
@@ -27,7 +27,13 @@ source "$LIBRARY/util/message.sh"
 source "$LIBRARY/util/util.sh"
 
 
-lint_package_functions=('lint_control_fields') # We want to make sure any control fields specified in a package() function are still valid.
+lint_package_functions=(
+	'lint_control_fields'
+	'lint_depends'
+	'lint_optdepends'
+	'lint_conflicts'
+	'lint_provides'
+)
 
 for lib in "$LIBRARY/lint_package/"*.sh; do
 	source "$lib"

--- a/src/functions/util/pkgbuild.sh
+++ b/src/functions/util/pkgbuild.sh
@@ -312,3 +312,15 @@ split_version() {
 	pkgver="$(echo "${ver}" | sed 's|^[^:]*:||' | sed 's|-.*||')"
 	pkgrel="$(echo "${ver}" | grep '-' | sed 's|^[^-]*-||')"
 }
+
+# Convert Debian styled dependencies ('pkg (>> 1)') into makedeb styled ones ('pkg>1').
+# This doesn't validate that passed in arguments are syntactically correct, make sure
+# this is called from somewhere where sources have already been validated.
+debian_to_makedeb_deps() {
+	local prefix="${1}"
+	local packages=("${@:2}")
+
+	for pkg in "${packages[@]}"; do
+		echo "${prefix}$(echo "${pkg}" | sed -e 's|[ ()]||g' -e 's|<<|<|g' -e 's|>>|>|g')"
+	done
+}

--- a/src/main.sh
+++ b/src/main.sh
@@ -775,15 +775,16 @@ run_single_packaging() {
 			debian_to_makedeb_deps 'p!' "${predepends[@]}"
 		)
 	fi
+	predepends=()
 
 	if [[ "${#optdepends[@]}" -eq 0 ]]; then
-		suggests=()
-		recommends=()
 		mapfile -t optdepends < <(
 			debian_to_makedeb_deps 'r!' "${recommends[@]}"
 			debian_to_makedeb_deps 's!' "${suggests[@]}"
 		)
 	fi
+	recommends=()
+	suggests=()
 
 	if [[ "${conflicts[*]}" == "${conflicts_backup[*]}" ]]; then
 		mapfile -t conflicts < <(debian_to_makedeb_deps '' "${conflicts[@]}")

--- a/src/main.sh
+++ b/src/main.sh
@@ -793,6 +793,10 @@ run_single_packaging() {
 		mapfile -t provides < <(debian_to_makedeb_deps '' "${provides[@]}")
 	fi
 
+	if [[ "${replaces[*]}" == "${replaces_backup[*]}" ]]; then
+		mapfile -t provides < <(debian_to_makedeb_deps '' "${provides[@]}")
+	fi
+
 	# Lint, convert deps, and make the package.
 	lint_package || exit $E_PACKAGE_FAILED
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -757,6 +757,8 @@ restore_package_variables() {
 }
 
 run_single_packaging() {
+	backup_package_variables
+
 	local pkgdir="$pkgdirbase/$pkgname"
 	mkdir "$pkgdir"
 	if [[ -n $1 ]] || (( PKGFUNC )); then
@@ -764,18 +766,61 @@ run_single_packaging() {
 	fi
 	tidy_install
 
+	# If the package didn't overwrite dependency arrays, we need to format
+	# the dependencies back to makedeb-styled ones, as they've already been formatted
+	# for control files before now.
+	if [[ "${depends[*]}" == "${depends_backup[*]}" ]]; then
+		mapfile -t depends < <(
+			debian_to_makedeb_deps '' "${depends[@]}"
+			debian_to_makedeb_deps 'p!' "${predepends[@]}"
+		)
+	fi
+
+	if [[ "${#optdepends[@]}" -eq 0 ]]; then
+		suggests=()
+		recommends=()
+		mapfile -t optdepends < <(
+			debian_to_makedeb_deps 'r!' "${recommends[@]}"
+			debian_to_makedeb_deps 's!' "${suggests[@]}"
+		)
+	fi
+
+	if [[ "${conflicts[*]}" == "${conflicts_backup[*]}" ]]; then
+		mapfile -t conflicts < <(debian_to_makedeb_deps '' "${conflicts[@]}")
+	fi
+
+	if [[ "${provides[*]}" == "${provides_backup[*]}" ]]; then
+		mapfile -t provides < <(debian_to_makedeb_deps '' "${provides[@]}")
+	fi
+
+	# Lint, convert deps, and make the package.
 	lint_package || exit $E_PACKAGE_FAILED
+
+	convert_dependencies
+
+	remove_optdepends_description recommends "${recommends[@]}"
+	remove_optdepends_description suggests "${suggests[@]}"
+
+	convert_relationships predepends "${predepends[@]}"
+	convert_relationships depends "${depends[@]}"
+	convert_relationships makedepends "${makedepends[@]}"
+	convert_relationships checkdepends "${checkdepends[@]}"
+	convert_relationships recommends "${recommends[@]}"
+	convert_relationships suggests "${suggests[@]}"
+	convert_relationships conflicts "${conflicts[@]}"
+	convert_relationships provides "${provides[@]}"
+	convert_relationships replaces "${replaces[@]}"
+	convert_relationships breaks "${breaks[@]}"
+
 	create_package
+
+	restore_package_variables
 }
 
 run_split_packaging() {
-	local pkgname_backup=("${pkgname[@]}")
-	backup_package_variables
-	for pkgname in ${pkgname_backup[@]}; do
+	for pkgname in ${pkgname[@]}; do
 		run_single_packaging $pkgname
-		restore_package_variables
 	done
-	pkgname=("${pkgname_backup[@]}")
 }
 
 check_distro_variables() {

--- a/src/main.sh
+++ b/src/main.sh
@@ -793,9 +793,9 @@ run_single_packaging() {
 	if [[ "${provides[*]}" == "${provides_backup[*]}" ]]; then
 		mapfile -t provides < <(debian_to_makedeb_deps '' "${provides[@]}")
 	fi
-
+	
 	if [[ "${replaces[*]}" == "${replaces_backup[*]}" ]]; then
-		mapfile -t provides < <(debian_to_makedeb_deps '' "${provides[@]}")
+		mapfile -t replaces < <(debian_to_makedeb_deps '' "${replaces[@]}")
 	fi
 
 	# Lint, convert deps, and make the package.

--- a/test/tests/depends.bats
+++ b/test/tests/depends.bats
@@ -54,6 +54,26 @@ load ../util/util
     [[ "$(cat pkg/testpkg/DEBIAN/control | grep '^Depends:')" == "Depends: bash" ]]
 }
 
+@test "correct depends - valid dependency prefixes in package()" {
+    package() {
+        depends=('bats2>0' 'p!bash2')
+    }
+
+    pkgbuild string maintainer1 'Foo Bar <foo@bar.com>'
+    pkgbuild string pkgname testpkg
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild string pkgdesc "package description"
+    pkgbuild array arch any
+    pkgbuild array depends 'p!bats>0' 'bash'
+    pkgbuild function package
+    pkgbuild clean
+    makedeb -d
+
+    [[ "$(cat pkg/testpkg/DEBIAN/control | grep '^Pre-Depends')" == "Pre-Depends: bash2" ]]
+    [[ "$(cat pkg/testpkg/DEBIAN/control | grep '^Depends:')" == "Depends: bats2 (>> 0)" ]]
+}
+
 @test "correct depends - separate by pipe" {
     pkgbuild string maintainer1 'Foo Bar <foo@bar.com>'
     pkgbuild string pkgname testpkg


### PR DESCRIPTION
Previously entering something like "depends=('hi=2')" in the 'package()' function added 'Depends: hi=2' to the control file, when it should be adding 'Depends: hi (= 2)' like normally defined dependencies.
