### PR TITLE
Allow installation script to run noninteractively

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -76,7 +76,7 @@ echo
 if (( "${noninteractive_mode}" )) && [[ "${MAKEDEB_RELEASE:+x}" == '' ]]; then
     error "The script was ran in noninteractive mode, but no makedeb package was specified to install."
     die_cmd "Please specify a package to install via the 'MAKEDEB_RELEASE' environment variable."
-else if [[ "${MAKEDEB_RELEASE:+x}" == '' ]]; then
+elif [[ "${MAKEDEB_RELEASE:+x}" == '' ]]; then
     msg "Multiple releases of makedeb are available for installation."
     msg "Currently, you can install one of 'makedeb', 'makedeb-beta', or"
     msg "'makedeb-alpha'."

--- a/install.sh
+++ b/install.sh
@@ -91,6 +91,8 @@ elif [[ "${MAKEDEB_RELEASE:+x}" == '' ]]; then
 
         break
     done
+    
+    echo
 fi
 
 case "${MAKEDEB_RELEASE}" in
@@ -102,7 +104,6 @@ case "${MAKEDEB_RELEASE}" in
         exit 1 ;;
 esac
 
-echo
 msg "Proceeding to install '${MAKEDEB_RELEASE}'..."
 
 msg "Setting up makedeb APT repository..."

--- a/install.sh
+++ b/install.sh
@@ -104,8 +104,6 @@ case "${MAKEDEB_RELEASE}" in
         exit 1 ;;
 esac
 
-msg "Proceeding to install '${MAKEDEB_RELEASE}'..."
-
 msg "Setting up makedeb APT repository..."
 if ! wget -qO - "https://proget.${makedeb_url}/debian-feeds/makedeb.pub" | gpg --dearmor | sudo tee /usr/share/keyrings/makedeb-archive-keyring.gpg 1> /dev/null; then
     die_cmd "Failed to set up makedeb APT repository."
@@ -117,6 +115,7 @@ if ! sudo apt-get update "${apt_args[@]}"; then
     die_cmd "Failed to update APT cache."
 fi
 
+echo
 msg "Installing '${MAKEDEB_RELEASE}'..."
 if ! sudo apt-get install "${apt_args[@]}" -- "${MAKEDEB_RELEASE}"; then
     die_cmd "Failed to install package."

--- a/install.sh
+++ b/install.sh
@@ -84,8 +84,8 @@ elif [[ "${MAKEDEB_RELEASE:+x}" == '' ]]; then
     while true; do
         read -p "$(question "Which release would you like? ")" MAKEDEB_RELEASE
 
-        if echo "${MAKEDEB_RELEASE}" | grep -qE '^makedeb$|^makedeb-beta$|^makedeb-alpha$'; then
-            error "Invalid response: ${response}"
+        if ! echo "${MAKEDEB_RELEASE}" | grep -qE '^makedeb$|^makedeb-beta$|^makedeb-alpha$'; then
+            error "Invalid response: ${MAKEDEB_RELEASE}"
             continue
         fi
 

--- a/install.sh
+++ b/install.sh
@@ -51,7 +51,7 @@ echo "${color_green}[#]${color_normal} ${color_orange}makedeb Installer${color_n
 echo "-------------------------"
 echo
 
-if echo "${-}" | grep -q i; then
+if ! echo "${-}" | grep -q i; then
     msg "Running in noninteractive mode."
     noninteractive_mode=1
     export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Skipping the consequent prompt allows the script to be used without user input.