### PR TITLE
Support sub-packages having `arch=('all')` v2

### DIFF
--- a/src/functions/lint_pkgbuild/arch.sh
+++ b/src/functions/lint_pkgbuild/arch.sh
@@ -63,7 +63,7 @@ lint_arch() {
 
 	for name in "${pkgname[@]}"; do
 		get_pkgbuild_attribute "$name" 'arch' 1 list
-		if [[ $list && $list != 'any' ]] && ! in_array "${MAKEDEB_DPKG_ARCHITECTURE}" "${list[@]}"; then
+		if [[ $list && $list != 'any' && $list != 'all' ]] && ! in_array "${MAKEDEB_DPKG_ARCHITECTURE}" "${list[@]}"; then
 			if (( ! IGNOREARCH )); then
 				error "$(gettext "%s is not available for the '%s' architecture.")" "$name" "${MAKEDEB_DPKG_ARCHITECTURE}"
 				ret=1

--- a/test/tests/arch.bats
+++ b/test/tests/arch.bats
@@ -36,3 +36,23 @@ load ../util/util
     [[ "${status}" == "12" ]]
     [[ "${output}" == "[!] testpkg is not available for the 'amd64' architecture." ]]
 }
+@test "allow arch all in sub packages" {
+    package_testpkg-doc() {
+      arch=('all')
+    }
+
+    package_testpkg() {
+      echo ''
+    }
+
+    pkgbuild string maintainer1 'Foo Bar <foo@bar.com>'
+    pkgbuild array pkgname testpkg testpkg-doc
+    pkgbuild string pkgver 1.0.0
+    pkgbuild string pkgrel 1
+    pkgbuild string pkgdesc "package description"
+    pkgbuild array arch amd64
+    pkgbuild function package_testpkg
+    pkgbuild function package_testpkg-doc
+    pkgbuild clean
+    makedeb --lint
+}


### PR DESCRIPTION
This patch allows sub-packages to override the arch attribute setting it to `all`.

The use case for this feature is when generating documentation packages that can be installed in any architecture.

For example:

```bash
pkgbase='project'
pkgname=('project' 'project-doc')
arch=('amd64')
...
function package_project-doc() {
    arch=('all');
}
```

Before this change the linting phase gave an error that the `project-doc` package was not available for **arch=amd64**.
Setting the `project-doc` package arch to **'any'** changes the final deb to have **arch=amd64**, which breaks the usage of *all* for arch independent packages.  

This change was the simplest way I could find for the above to pass the linting stage and have the correct final *arch* for the `project-doc` package.

Please note that this continues to allow for the **'any'** value in the arch field.
