### PR TITLE
Fix clippy lints in makedeb-rs

### DIFF
--- a/src/makedeb-rs/src/cache.rs
+++ b/src/makedeb-rs/src/cache.rs
@@ -104,7 +104,7 @@ pub fn run_transaction<T: ToString>(
             .to_string();
 
             let apt_version = deb_cache
-                .get(&format!("{}:{}", pkgname, architecture))
+                .get(&format!("{pkgname}:{architecture}"))
                 .unwrap()
                 .get_version(&version)
                 .unwrap();

--- a/src/makedeb-rs/src/install.rs
+++ b/src/makedeb-rs/src/install.rs
@@ -61,7 +61,7 @@ pub(crate) fn install(
         .unwrap()
         .trim()
         .to_string();
-        let pkgname = format!("{}:{}", pkgname_bare, architecture);
+        let pkgname = format!("{pkgname_bare}:{architecture}");
         pkgnames.push(pkgname.clone());
         pkgs.push(Package { pkgname, version });
         debs.push(deb);


### PR DESCRIPTION
This patch fixes the failure when running the unit tests due to the presence of clippy lint messages. 